### PR TITLE
Issue #70: add Try/TryAsync methods with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ var output3 = await Result.Ok(user)
 
 These overloads are available for sync, `Task`, and `ValueTask` variants (left/right/both async forms).
 
+### Try
+
+Executes code and converts thrown exceptions to failed `Result` values.
+
+```csharp
+var saveResult = ResultExtensions.Try(() => Save(customer));
+
+var loadResult = await ResultExtensions.TryAsync(
+    async () => await repository.LoadAsync(id),
+    ex => $"Load failed: {ex.Message}");
+```
+
 ### Check
 
 Executes a function only if the Result is successful, acting as a validation step in a chain.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Try.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Try.Task.cs
@@ -1,0 +1,51 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Attempts to execute the supplied asynchronous action and returns a Result indicating success or failure.
+    /// </summary>
+    /// <param name="action">The asynchronous action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A successful Result when no exception is thrown; otherwise a failed Result.</returns>
+    public static async Task<Result> TryAsync(Func<Task> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        errorHandler ??= static exception => exception.Message;
+
+        try
+        {
+            await action().ConfigureAwait(false);
+
+            return Result.Ok();
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail(errorHandler(exception));
+        }
+    }
+
+    /// <summary>
+    /// Attempts to execute the supplied asynchronous function and returns a Result indicating success or failure.
+    /// </summary>
+    /// <typeparam name="TValue">The return type of the function.</typeparam>
+    /// <param name="func">The asynchronous function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A successful Result containing the function value when no exception is thrown; otherwise a failed Result.</returns>
+    public static async Task<Result<TValue>> TryAsync<TValue>(Func<Task<TValue>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        errorHandler ??= static exception => exception.Message;
+
+        try
+        {
+            var value = await func().ConfigureAwait(false);
+
+            return Result.Ok(value);
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail<TValue>(errorHandler(exception));
+        }
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Try.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Try.ValueTask.cs
@@ -1,0 +1,51 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Attempts to execute the supplied asynchronous action and returns a Result indicating success or failure.
+    /// </summary>
+    /// <param name="action">The asynchronous action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A successful Result when no exception is thrown; otherwise a failed Result.</returns>
+    public static async ValueTask<Result> TryAsync(Func<ValueTask> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        errorHandler ??= static exception => exception.Message;
+
+        try
+        {
+            await action().ConfigureAwait(false);
+
+            return Result.Ok();
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail(errorHandler(exception));
+        }
+    }
+
+    /// <summary>
+    /// Attempts to execute the supplied asynchronous function and returns a Result indicating success or failure.
+    /// </summary>
+    /// <typeparam name="TValue">The return type of the function.</typeparam>
+    /// <param name="func">The asynchronous function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A successful Result containing the function value when no exception is thrown; otherwise a failed Result.</returns>
+    public static async ValueTask<Result<TValue>> TryAsync<TValue>(Func<ValueTask<TValue>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        errorHandler ??= static exception => exception.Message;
+
+        try
+        {
+            var value = await func().ConfigureAwait(false);
+
+            return Result.Ok(value);
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail<TValue>(errorHandler(exception));
+        }
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Try.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Try.cs
@@ -1,0 +1,49 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Attempts to execute the supplied action and returns a Result indicating success or failure.
+    /// </summary>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A successful Result when no exception is thrown; otherwise a failed Result.</returns>
+    public static Result Try(Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        errorHandler ??= static exception => exception.Message;
+
+        try
+        {
+            action();
+
+            return Result.Ok();
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail(errorHandler(exception));
+        }
+    }
+
+    /// <summary>
+    /// Attempts to execute the supplied function and returns a Result indicating success or failure.
+    /// </summary>
+    /// <typeparam name="TValue">The return type of the function.</typeparam>
+    /// <param name="func">The function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A successful Result containing the function value when no exception is thrown; otherwise a failed Result.</returns>
+    public static Result<TValue> Try<TValue>(Func<TValue> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        errorHandler ??= static exception => exception.Message;
+
+        try
+        {
+            return Result.Ok(func());
+        }
+        catch (Exception exception)
+        {
+            return Result.Fail<TValue>(errorHandler(exception));
+        }
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.Base.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class TryTestsBase : TestBase
+{
+    protected const string TryExceptionMessage = "Try Exception Message";
+    protected const string CustomErrorMessage = "Custom Try Error Message";
+
+    protected static void SuccessAction()
+    {
+    }
+
+    protected static void FailAction() => throw new InvalidOperationException(TryExceptionMessage);
+
+    protected static TValue SuccessFunc() => TValue.Value;
+
+    protected static TValue FailFunc() => throw new InvalidOperationException(TryExceptionMessage);
+
+    protected static Task SuccessTaskAction() => Task.CompletedTask;
+
+    protected static Task FailTaskAction() => Task.FromException(new InvalidOperationException(TryExceptionMessage));
+
+    protected static Task<TValue> SuccessTaskFunc() => Task.FromResult(TValue.Value);
+
+    protected static Task<TValue> FailTaskFunc() => Task.FromException<TValue>(new InvalidOperationException(TryExceptionMessage));
+
+    protected static ValueTask SuccessValueTaskAction() => ValueTask.CompletedTask;
+
+    protected static ValueTask FailValueTaskAction() => ValueTask.FromException(new InvalidOperationException(TryExceptionMessage));
+
+    protected static ValueTask<TValue> SuccessValueTaskFunc() => ValueTask.FromResult(TValue.Value);
+
+    protected static ValueTask<TValue> FailValueTaskFunc() => ValueTask.FromException<TValue>(new InvalidOperationException(TryExceptionMessage));
+
+    protected static string CustomErrorHandler(Exception _) => CustomErrorMessage;
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.Task.cs
@@ -1,0 +1,73 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TryTestsTask : TryTestsBase
+{
+    [Fact]
+    public async Task TryAsyncTaskActionIsSuccessfulExpectedResultOk()
+    {
+        var output = await ResultExtensions.TryAsync(SuccessTaskAction);
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskActionThrowsExpectedResultFailWithDefaultError()
+    {
+        var output = await ResultExtensions.TryAsync(FailTaskAction);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskActionThrowsAndCustomErrorHandlerExpectedResultFailWithCustomError()
+    {
+        var output = await ResultExtensions.TryAsync(FailTaskAction, CustomErrorHandler);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskActionIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.TryAsync((Func<Task>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskFuncIsSuccessfulExpectedResultOkWithValue()
+    {
+        var output = await ResultExtensions.TryAsync(SuccessTaskFunc);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskFuncThrowsExpectedResultFailWithDefaultError()
+    {
+        var output = await ResultExtensions.TryAsync(FailTaskFunc);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskFuncThrowsAndCustomErrorHandlerExpectedResultFailWithCustomError()
+    {
+        var output = await ResultExtensions.TryAsync(FailTaskFunc, CustomErrorHandler);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncTaskFuncIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.TryAsync<TValue>((Func<Task<TValue>>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.ValueTask.cs
@@ -1,0 +1,73 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TryTestsValueTask : TryTestsBase
+{
+    [Fact]
+    public async Task TryAsyncValueTaskActionIsSuccessfulExpectedResultOk()
+    {
+        var output = await ResultExtensions.TryAsync(SuccessValueTaskAction);
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskActionThrowsExpectedResultFailWithDefaultError()
+    {
+        var output = await ResultExtensions.TryAsync(FailValueTaskAction);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskActionThrowsAndCustomErrorHandlerExpectedResultFailWithCustomError()
+    {
+        var output = await ResultExtensions.TryAsync(FailValueTaskAction, CustomErrorHandler);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskActionIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.TryAsync((Func<ValueTask>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskFuncIsSuccessfulExpectedResultOkWithValue()
+    {
+        var output = await ResultExtensions.TryAsync(SuccessValueTaskFunc);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskFuncThrowsExpectedResultFailWithDefaultError()
+    {
+        var output = await ResultExtensions.TryAsync(FailValueTaskFunc);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskFuncThrowsAndCustomErrorHandlerExpectedResultFailWithCustomError()
+    {
+        var output = await ResultExtensions.TryAsync(FailValueTaskFunc, CustomErrorHandler);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task TryAsyncValueTaskFuncIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.TryAsync<TValue>((Func<ValueTask<TValue>>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TryTests.cs
@@ -1,0 +1,73 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TryTests : TryTestsBase
+{
+    [Fact]
+    public void TryActionIsSuccessfulExpectedResultOk()
+    {
+        var output = ResultExtensions.Try(SuccessAction);
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryActionThrowsExpectedResultFailWithDefaultError()
+    {
+        var output = ResultExtensions.Try(FailAction);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public void TryActionThrowsAndCustomErrorHandlerExpectedResultFailWithCustomError()
+    {
+        var output = ResultExtensions.Try(FailAction, CustomErrorHandler);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public void TryActionIsNullExpectedThrowArgumentNullException()
+    {
+        var action = () => ResultExtensions.Try(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryFuncIsSuccessfulExpectedResultOkWithValue()
+    {
+        var output = ResultExtensions.Try(SuccessFunc);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public void TryFuncThrowsExpectedResultFailWithDefaultError()
+    {
+        var output = ResultExtensions.Try(FailFunc);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public void TryFuncThrowsAndCustomErrorHandlerExpectedResultFailWithCustomError()
+    {
+        var output = ResultExtensions.Try(FailFunc, CustomErrorHandler);
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public void TryFuncIsNullExpectedThrowArgumentNullException()
+    {
+        var action = () => ResultExtensions.Try<TValue>(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary
Implements `Try` support aligned with CSharpFunctionalExtensions and current project conventions.

### Added API
- `ResultExtensions.Try(Action, Func<Exception, string>?)`
- `ResultExtensions.Try<TValue>(Func<TValue>, Func<Exception, string>?)`
- `ResultExtensions.TryAsync(Func<Task>, Func<Exception, string>?)`
- `ResultExtensions.TryAsync<TValue>(Func<Task<TValue>>, Func<Exception, string>?)`
- `ResultExtensions.TryAsync(Func<ValueTask>, Func<Exception, string>?)`
- `ResultExtensions.TryAsync<TValue>(Func<ValueTask<TValue>>, Func<Exception, string>?)`

### Tests
Added dedicated test suite for:
- success paths
- failure paths (exception -> failed `Result`)
- custom error handler mapping
- null delegate argument guards

### Documentation
- Updated README with `Try` usage examples.

## Verification
- `dotnet test` passes on `net8.0`, `net9.0`, `net10.0`.

Closes #70