### PR TITLE
Issue #71: expand Bind family with missing synchronous overloads

### DIFF
--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Bind.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Bind.cs
@@ -8,6 +8,61 @@ public static partial class ResultExtensions
     /// <param name="result">The Result to bind the function to.</param>
     /// <param name="func">The function to bind to the Result.</param>
     /// <returns>A new Result that is the result of executing the bound function, or the original failed Result if it was failed.</returns>
+    public static Result Bind(this Result result, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        return result.IternalBind(func);
+    }
+
+    /// <summary>
+    /// Binds a function to a Result, executing it only if the Result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value returned by the function.</typeparam>
+    /// <param name="result">The Result to bind the function to.</param>
+    /// <param name="func">The function to bind to the Result.</param>
+    /// <returns>A new Result that is the result of executing the bound function, or a failed result with original errors if it was failed.</returns>
+    public static Result<TValue> Bind<TValue>(this Result result, Func<Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed ? Result.Fail<TValue>(result.Errors) : func();
+    }
+
+    /// <summary>
+    /// Binds a function to a Result, executing it only if the Result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="result">The Result to bind the function to.</param>
+    /// <param name="func">The function to bind to the Result.</param>
+    /// <returns>A new Result that is the result of executing the bound function, or the original failed Result if it was failed.</returns>
+    public static Result Bind<TValue>(this Result<TValue> result, Func<TValue, Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed ? Result.Fail(result.Errors) : func(result.Value);
+    }
+
+    /// <summary>
+    /// Binds a function to a Result, executing it only if the Result is successful.
+    /// </summary>
+    /// <typeparam name="TInput">The type of the value in the Result.</typeparam>
+    /// <typeparam name="TOutput">The type of the value returned by the function.</typeparam>
+    /// <param name="result">The Result to bind the function to.</param>
+    /// <param name="func">The function to bind to the Result.</param>
+    /// <returns>A new Result that is the result of executing the bound function, or a failed result with original errors if it was failed.</returns>
+    public static Result<TOutput> Bind<TInput, TOutput>(this Result<TInput> result, Func<TInput, Result<TOutput>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed ? Result.Fail<TOutput>(result.Errors) : func(result.Value);
+    }
+
+    /// <summary>
+    /// Binds a function to a Result, executing it only if the Result is successful.
+    /// </summary>
+    /// <param name="result">The Result to bind the function to.</param>
+    /// <param name="func">The function to bind to the Result.</param>
+    /// <returns>A new Result that is the result of executing the bound function, or the original failed Result if it was failed.</returns>
     internal static Result IternalBind(this Result result, Func<Result> func)
     {
         ArgumentNullException.ThrowIfNull(func);

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTests.Base.cs
@@ -9,6 +9,24 @@ public abstract class BindTestsBase : TestBase
         FuncExecuted = true;
         return Result.Ok();
     }
+
+    protected Result FailFunc()
+    {
+        FuncExecuted = true;
+        return Result.Fail(ErrorMessage);
+    }
+
+    protected Result<string> OkStringFunc()
+    {
+        FuncExecuted = true;
+        return Result.Ok("ok");
+    }
+
+    protected Result<string> FailStringFunc()
+    {
+        FuncExecuted = true;
+        return Result.Fail<string>(ErrorMessage);
+    }
     protected Task<Result> TaskOkFuncAsync()
     {
         FuncExecuted = true;
@@ -25,6 +43,30 @@ public abstract class BindTestsBase : TestBase
     {
         FuncExecuted = true;
         return Result.Ok(value);
+    }
+
+    protected Result OkFromTFunc(TValue value)
+    {
+        FuncExecuted = true;
+        return Result.Ok();
+    }
+
+    protected Result FailFromTFunc(TValue value)
+    {
+        FuncExecuted = true;
+        return Result.Fail(ErrorMessage);
+    }
+
+    protected Result<string> OkStringFromTFunc(TValue value)
+    {
+        FuncExecuted = true;
+        return Result.Ok("ok");
+    }
+
+    protected Result<string> FailStringFromTFunc(TValue value)
+    {
+        FuncExecuted = true;
+        return Result.Fail<string>(ErrorMessage);
     }
 
     protected Task<Result<TValue>> TaskOkTFuncAsync(TValue value)

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTests.cs
@@ -3,7 +3,7 @@
 public sealed class BindTests : BindTestsBase
 {
     [Fact]
-    public void BindReturnsFailureAndDoesNotExecuteFunc()
+    public void InternalBindReturnsFailureAndDoesNotExecuteFunc()
     {
         var output = Result.Fail(ErrorMessage)
             .IternalBind(OkFunc);
@@ -11,7 +11,7 @@ public sealed class BindTests : BindTestsBase
     }
 
     [Fact]
-    public void BindSelectsNewResult()
+    public void InternalBindSelectsNewResult()
     {
         var output = Result.Ok()
             .IternalBind(OkFunc);
@@ -19,7 +19,7 @@ public sealed class BindTests : BindTestsBase
     }
 
     [Fact]
-    public void BindTReturnsFailureAndDoesNotExecuteFunc()
+    public void InternalBindTReturnsFailureAndDoesNotExecuteFunc()
     {
         var output = Result.Fail<TValue>(ErrorMessage)
             .IternalBind(OkTFunc);
@@ -27,10 +27,96 @@ public sealed class BindTests : BindTestsBase
     }
 
     [Fact]
-    public void BindTSelectsNewResult()
+    public void InternalBindTSelectsNewResult()
     {
         var output = Result.Ok(TValue.Value)
             .IternalBind(OkTFunc);
         AssertSuccess(output);
+    }
+
+    [Fact]
+    public void BindResultReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail(ErrorMessage).Bind(OkFunc);
+
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public void BindResultSelectsNewResult()
+    {
+        var output = Result.Ok().Bind(OkFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public void BindResultToResultTSelectsNewResult()
+    {
+        var output = Result.Ok().Bind(OkStringFunc);
+
+        AssertSuccess(output);
+        output.Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public void BindResultToResultTReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail(ErrorMessage).Bind(OkStringFunc);
+
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public void BindResultTToResultSelectsNewResult()
+    {
+        var output = Result.Ok(TValue.Value).Bind(OkFromTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public void BindResultTToResultReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail<TValue>(ErrorMessage).Bind(OkFromTFunc);
+
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public void BindResultTToResultPropagatesFuncFailure()
+    {
+        var output = Result.Ok(TValue.Value).Bind(FailFromTFunc);
+
+        output.IsFailed.Should().BeTrue();
+        FuncExecuted.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+
+    [Fact]
+    public void BindResultTToResultTSelectsNewResult()
+    {
+        var output = Result.Ok(TValue.Value).Bind(OkStringFromTFunc);
+
+        AssertSuccess(output);
+        output.Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public void BindResultTToResultTReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail<TValue>(ErrorMessage).Bind(OkStringFromTFunc);
+
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public void BindResultTToResultTPropagatesFuncFailure()
+    {
+        var output = Result.Ok(TValue.Value).Bind(FailStringFromTFunc);
+
+        output.IsFailed.Should().BeTrue();
+        FuncExecuted.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
     }
 }


### PR DESCRIPTION
## Summary
Implements issue #71 by adding missing public synchronous `Bind` overloads for `Result` and `Result<T>` to close overload-coverage gaps.

### Added overloads
- `Bind(this Result, Func<Result>)`
- `Bind<TValue>(this Result, Func<Result<TValue>>)`
- `Bind<TValue>(this Result<TValue>, Func<TValue, Result>)`
- `Bind<TInput, TOutput>(this Result<TInput>, Func<TInput, Result<TOutput>>)`

### Behavior
- Failure short-circuiting preserved.
- Failure propagation remains consistent with existing `BindAsync` behavior.

### Tests
Expanded `Bind` tests to cover:
- source failure short-circuiting
- success flows
- function failure propagation
- compatibility for new `Result` / `Result<T>` signatures

## Verification
- `dotnet test` passes on `net8.0`, `net9.0`, and `net10.0`.

Closes #71