### PR TITLE
feat: expand MapAsync and TapAsync with missing mixed async overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Executes an action if the result is successful and return the original result.
 public async Task OnActionAsync()
 ...
 await Result.Ok().TapAsync(OnActionAsync);
+
+public ValueTask OnActionValueTaskAsync()
+...
+await Result.Ok().TapAsync(OnActionValueTaskAsync);
+
+public Task<Result> GetResultAsync()
+...
+await GetResultAsync().TapAsync(OnActionValueTaskAsync);
 ```
 
 ### Match
@@ -123,6 +131,14 @@ If the Result is failed, returns a failed Result with the same errors.
 public async Task<Dto> MapAsync(int value)
 ...
 var output = await Result.Ok(1).MapAsync(MapAsync);
+
+public ValueTask<Dto> MapValueTaskAsync(int value)
+...
+var output2 = await Result.Ok(1).MapAsync(MapValueTaskAsync);
+
+public Task<Result<int>> GetNumberAsync()
+...
+var output3 = await GetNumberAsync().MapAsync(MapValueTaskAsync);
 ```
 
 ## Example

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Map.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Map.Task.cs
@@ -18,6 +18,23 @@ public static partial class ResultExtensions
     }
 
     /// <summary>
+    /// Asynchronously maps a Result from a task using a function that returns a ValueTask.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value returned by the function.</typeparam>
+    /// <param name="resultTask">The task that produces the Result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <returns>A task containing the mapped Result.</returns>
+    public static async Task<Result<TValue>> MapAsync<TValue>(
+        this Task<Result> resultTask,
+        Func<ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Asynchronously maps a Result from a task using a function that returns a task.
     /// </summary>
     /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
@@ -28,6 +45,24 @@ public static partial class ResultExtensions
     public static async Task<Result<TValueOut>> MapAsync<TValue, TValueOut>(
         this Task<Result<TValue>> resultTask,
         Func<TValue, Task<TValueOut>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously maps a Result from a task using a function that returns a ValueTask.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <typeparam name="TValueOut">The type of the value returned by the function.</typeparam>
+    /// <param name="resultTask">The task that produces the Result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <returns>A task containing the mapped Result.</returns>
+    public static async Task<Result<TValueOut>> MapAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
 

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Map.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Map.ValueTask.cs
@@ -20,6 +20,23 @@ public static partial class ResultExtensions
     }
 
     /// <summary>
+    /// Asynchronously maps a Result from a ValueTask using a function that returns a Task.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value returned by the function.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <returns>A ValueTask containing the mapped Result.</returns>
+    public static async ValueTask<Result<TValue>> MapAsync<TValue>(
+        this ValueTask<Result> resultTask,
+        Func<Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Asynchronously maps a Result from a ValueTask using a function that returns a ValueTask.
     /// </summary>
     /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
@@ -30,6 +47,24 @@ public static partial class ResultExtensions
     public static async ValueTask<Result<TValueOut>> MapAsync<TValue, TValueOut>(
         this ValueTask<Result<TValue>> resultTask,
         Func<TValue, ValueTask<TValueOut>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously maps a Result from a ValueTask using a function that returns a Task.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <typeparam name="TValueOut">The type of the value returned by the function.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <returns>A ValueTask containing the mapped Result.</returns>
+    public static async ValueTask<Result<TValueOut>> MapAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> func)
     {
         ArgumentNullException.ThrowIfNull(func);
 

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Tap.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Tap.Task.cs
@@ -23,6 +23,24 @@ public static partial class ResultExtensions
     /// <summary>
     /// Executes a function if the result of a task is successful.
     /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is successful.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is successful.
+    /// </summary>
     /// <typeparam name="T">The type of the value contained in the result.</typeparam>
     /// <param name="resultTask">The task that produces the result.</param>
     /// <param name="func">The function to execute if the result is successful.</param>
@@ -44,9 +62,47 @@ public static partial class ResultExtensions
     /// </summary>
     /// <typeparam name="T">The type of the value contained in the result.</typeparam>
     /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is successful.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<T>> TapAsync<T>(this Task<Result<T>> resultTask, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is successful.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
     /// <param name="func">The function to execute if the result is successful. The function takes the value of the result as a parameter.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
     public static async Task<Result<T>> TapAsync<T>(this Task<Result<T>> resultTask, Func<T, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await func(result.Value).ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is successful.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is successful. The function takes the value of the result as a parameter.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<T>> TapAsync<T>(this Task<Result<T>> resultTask, Func<T, ValueTask> func)
     {
         ArgumentNullException.ThrowIfNull(func);
 

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Tap.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Tap.ValueTask.cs
@@ -23,6 +23,24 @@ public static partial class ResultExtensions
     /// <summary>
     /// Executes a function if the result of a task is successful.
     /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is successful.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapAsync(this ValueTask<Result> resultTask, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is successful.
+    /// </summary>
     /// <typeparam name="T">The type of the value contained in the result.</typeparam>
     /// <param name="resultTask">The task that produces the result.</param>
     /// <param name="func">The function to execute if the result is successful.</param>
@@ -44,9 +62,47 @@ public static partial class ResultExtensions
     /// </summary>
     /// <typeparam name="T">The type of the value contained in the result.</typeparam>
     /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is successful.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<T>> TapAsync<T>(this ValueTask<Result<T>> resultTask, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is successful.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
     /// <param name="func">The function to execute if the result is successful. The function takes the value of the result as a parameter.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
     public static async ValueTask<Result<T>> TapAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            await func(result.Value).ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is successful.
+    /// </summary>
+    /// <typeparam name="T">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is successful. The function takes the value of the result as a parameter.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<T>> TapAsync<T>(this ValueTask<Result<T>> resultTask, Func<T, Task> func)
     {
         ArgumentNullException.ThrowIfNull(func);
 

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTests.Task.cs
@@ -29,4 +29,32 @@ public sealed class MapTestsTask : MapTestsBase
         var output = await TaskOkResultTAsync().MapAsync(TaskMapFuncAsync);
         AssertSuccess(output);
     }
+
+    [Fact]
+    public async Task MapTaskWithValueTaskFuncReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await TaskFailResultAsync().MapAsync(ValueTaskMapFuncAsync);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task MapTaskWithValueTaskFuncSelectsNewResult()
+    {
+        var output = await Common.TestBase.TaskOkResultAsync().MapAsync(ValueTaskMapFuncAsync);
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public async Task MapTaskTWithValueTaskFuncReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await TaskFailResultTAsync().MapAsync(ValueTaskMapFuncAsync);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task MapTaskTWithValueTaskFuncSelectsNewResult()
+    {
+        var output = await TaskOkResultTAsync().MapAsync(ValueTaskMapFuncAsync);
+        AssertSuccess(output);
+    }
 }

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTests.ValueTask.cs
@@ -29,4 +29,32 @@ public sealed class MapTestsValueTask : MapTestsBase
         var output = await ValueTaskOkResultTAsync().MapAsync(ValueTaskMapFuncAsync);
         AssertSuccess(output);
     }
+
+    [Fact]
+    public async Task MapValueTaskWithTaskFuncReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await ValueTaskFailResultAsync().MapAsync(TaskMapFuncAsync);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task MapValueTaskWithTaskFuncSelectsNewResult()
+    {
+        var output = await Common.TestBase.ValueTaskOkResultAsync().MapAsync(TaskMapFuncAsync);
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public async Task MapValueTaskTWithTaskFuncReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await ValueTaskFailResultTAsync().MapAsync(TaskMapFuncAsync);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task MapValueTaskTWithTaskFuncSelectsNewResult()
+    {
+        var output = await ValueTaskOkResultTAsync().MapAsync(TaskMapFuncAsync);
+        AssertSuccess(output);
+    }
 }

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapTests.Task.cs
@@ -34,4 +34,37 @@ public sealed class TapTestsTask : TapTestsBase
 
         AssertSuccess(output, isSuccess);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TapExecutesValueTaskActionOnResultSuccessAndReturnsSelf(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage).AsTask();
+        var output = await result.TapAsync(ValueTaskActionEmptyAsync);
+
+        AssertSuccess(output, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TapTExecutesValueTaskActionOnResultSuccessAndReturnsSelf(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value).AsTask();
+        var output = await result.TapAsync(ValueTaskActionEmptyAsync);
+
+        AssertSuccess(output, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TapTExecutesValueTaskActionTOnResultSuccessAndReturnsSelf(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value).AsTask();
+        var output = await result.TapAsync(ValueTaskActionTAsync);
+
+        AssertSuccess(output, isSuccess);
+    }
 }

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapTests.ValueTask.cs
@@ -34,4 +34,37 @@ public sealed class TapTestsValueTask : TapTestsBase
 
         AssertSuccess(output, isSuccess);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TapExecutesTaskActionOnResultSuccessAndReturnsSelf(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage);
+        var output = await result.TapAsync(TaskActionEmptyAsync);
+
+        AssertSuccess(output, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TapTExecutesTaskActionOnResultSuccessAndReturnsSelf(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value);
+        var output = await result.TapAsync(TaskActionEmptyAsync);
+
+        AssertSuccess(output, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TapTExecutesTaskActionTOnResultSuccessAndReturnsSelf(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value);
+        var output = await result.TapAsync(TaskActionTAsync);
+
+        AssertSuccess(output, isSuccess);
+    }
 }


### PR DESCRIPTION
## Summary
- add missing mixed async overloads for `MapAsync`
  - `Task<Result*>` + `Func<..., ValueTask<...>>`
  - `ValueTask<Result*>` + `Func<..., Task<...>>`
- add missing mixed async overloads for `TapAsync`
  - `Task<Result*>` + `Func<..., ValueTask>`
  - `ValueTask<Result*>` + `Func<..., Task>`
- add test coverage for the new overload combinations
- update README with mixed `Task`/`ValueTask` examples

## Validation
- `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- passed on `net8.0`, `net9.0`, `net10.0`

Closes #73