### PR TITLE
feat: add Required method support for nullable result values

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ var output3 = await Result.Ok(user)
 
 These overloads are available for sync, `Task`, and `ValueTask` variants (left/right/both async forms).
 
+### Required
+
+Requires a successful result value to be non-null.
+If the source result is failed, errors are preserved.
+
+```csharp
+Result<string?> maybeName = Result.Ok<string?>(null);
+Result<string> requiredName = maybeName.Required("Name is required");
+
+Task<Result<string?>> maybeNameTask = GetNameAsync();
+Result<string> requiredFromTask = await maybeNameTask.RequiredAsync("Name is required");
+```
+
 ### Try
 
 Executes code and converts thrown exceptions to failed `Result` values.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Required.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Required.Task.Left.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Requires a successful task result value to be non-null.
+    /// </summary>
+    /// <typeparam name="TValue">The reference type contained in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A task containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async Task<Result<TValue>> RequiredAsync<TValue>(this Task<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Required(errorMessage);
+    }
+
+    /// <summary>
+    /// Requires a successful nullable struct task result value to have a value.
+    /// </summary>
+    /// <typeparam name="TValue">The value type contained in the nullable Result.</typeparam>
+    /// <param name="resultTask">The task that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A task containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async Task<Result<TValue>> RequiredAsync<TValue>(this Task<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Required(errorMessage);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Required.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Required.ValueTask.Left.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Requires a successful ValueTask result value to be non-null.
+    /// </summary>
+    /// <typeparam name="TValue">The reference type contained in the Result.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A ValueTask containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async ValueTask<Result<TValue>> RequiredAsync<TValue>(this ValueTask<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Required(errorMessage);
+    }
+
+    /// <summary>
+    /// Requires a successful nullable struct ValueTask result value to have a value.
+    /// </summary>
+    /// <typeparam name="TValue">The value type contained in the nullable Result.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A ValueTask containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async ValueTask<Result<TValue>> RequiredAsync<TValue>(this ValueTask<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Required(errorMessage);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Required.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Required.cs
@@ -1,0 +1,48 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Requires a successful result value to be non-null.
+    /// If the current Result is failed, returns a failed Result with the same errors.
+    /// If the current Result is successful but the value is null, returns a failed Result with the provided error message.
+    /// </summary>
+    /// <typeparam name="TValue">The reference type contained in the Result.</typeparam>
+    /// <param name="result">The result whose value is required to be non-null.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A successful Result with a non-null value or a failed Result.</returns>
+    public static Result<TValue> Required<TValue>(this Result<TValue?> result, string errorMessage)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValue>(result.Errors);
+        }
+
+        return result.Value is null ? Result.Fail<TValue>(errorMessage) : Result.Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Requires a successful nullable struct result value to have a value.
+    /// If the current Result is failed, returns a failed Result with the same errors.
+    /// If the current Result is successful but the value is null, returns a failed Result with the provided error message.
+    /// </summary>
+    /// <typeparam name="TValue">The value type contained in the nullable Result.</typeparam>
+    /// <param name="result">The result whose nullable value is required to be present.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A successful Result with a non-null value or a failed Result.</returns>
+    public static Result<TValue> Required<TValue>(this Result<TValue?> result, string errorMessage)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValue>(result.Errors);
+        }
+
+        return result.Value.HasValue ? Result.Ok(result.Value.Value) : Result.Fail<TValue>(errorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/RequiredTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/RequiredTests.Task.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class RequiredTestsTaskLeft
+{
+    [Fact]
+    public async Task RequiredTaskLeftReturnsFailureWhenValueIsNull()
+    {
+        var resultTask = Task.FromResult(Result.Ok<string?>(null));
+
+        var output = await resultTask.RequiredAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public async Task RequiredTaskLeftReturnsSuccessWhenValueIsNotNull()
+    {
+        var resultTask = Task.FromResult(Result.Ok<string?>("ok"));
+
+        var output = await resultTask.RequiredAsync("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task RequiredTaskLeftPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var resultTask = Task.FromResult(Result.Fail<string?>("Source failure"));
+
+        var output = await resultTask.RequiredAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value is required");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/RequiredTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/RequiredTests.ValueTask.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class RequiredTestsValueTaskLeft
+{
+    [Fact]
+    public async Task RequiredValueTaskLeftReturnsFailureWhenValueIsNull()
+    {
+        var resultTask = ValueTask.FromResult(Result.Ok<string?>(null));
+
+        var output = await resultTask.RequiredAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public async Task RequiredValueTaskLeftReturnsSuccessWhenValueIsNotNull()
+    {
+        var resultTask = ValueTask.FromResult(Result.Ok<string?>("ok"));
+
+        var output = await resultTask.RequiredAsync("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task RequiredValueTaskLeftPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var resultTask = ValueTask.FromResult(Result.Fail<string?>("Source failure"));
+
+        var output = await resultTask.RequiredAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value is required");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/RequiredTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/RequiredTests.cs
@@ -1,0 +1,71 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class RequiredTests
+{
+    [Fact]
+    public void RequiredReturnsFailureWhenValueIsNull()
+    {
+        var result = Result.Ok<string?>(null);
+
+        var output = result.Required("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public void RequiredReturnsSuccessWhenReferenceValueIsNotNull()
+    {
+        const string value = "ok";
+        var result = Result.Ok<string?>(value);
+
+        var output = result.Required("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void RequiredReturnsSuccessWhenNullableStructHasValue()
+    {
+        var result = Result.Ok<int?>(42);
+
+        var output = result.Required("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void RequiredReturnsFailureWhenNullableStructIsNull()
+    {
+        var result = Result.Ok<int?>(null);
+
+        var output = result.Required("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public void RequiredPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var result = Result.Fail<string?>("Source failure");
+
+        var output = result.Required("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public void RequiredThrowsWhenErrorMessageIsNull()
+    {
+        var result = Result.Ok<string?>("ok");
+
+        Action act = () => result.Required(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary
- add `Required` for nullable `Result<T?>` values:
  - reference types (`where T : class`)
  - nullable value types (`where T : struct`)
- add left-operand async overloads:
  - `Task<Result<T?>>.RequiredAsync(...)`
  - `ValueTask<Result<T?>>.RequiredAsync(...)`
- add tests for success/failure paths, failed-source preservation, and null-argument guard

## Validation
- `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- passed on `net8.0`, `net9.0`, `net10.0`

Closes #61