### PR TITLE
feat: add Select/SelectAsync aliases for Result mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ public Task<Result<int>> GetNumberAsync()
 var output3 = await GetNumberAsync().MapAsync(MapValueTaskAsync);
 ```
 
+### Select
+
+LINQ-friendly alias for `Map`.
+If the Result is failed, returns a failed Result with the same errors.
+
+```csharp
+var output = Result.Ok(1).Select(v => v + 1);
+
+public Task<Result<int>> GetNumberAsync()
+...
+var output2 = await GetNumberAsync().SelectAsync(v => v + 1);
+```
+
 ## Example
 
 ```csharp

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Select.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Select.Task.Left.cs
@@ -1,0 +1,31 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Selects a new Result from a task result using a synchronous selector.
+    /// This method is intended for LINQ query syntax and delegates to MapAsync.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the source Result.</typeparam>
+    /// <typeparam name="TValueOut">The type of the value returned by the selector.</typeparam>
+    /// <param name="resultTask">The task that produces the source Result.</param>
+    /// <param name="selector">The mapping function.</param>
+    /// <returns>A task containing the selected Result.</returns>
+    public static Task<Result<TValueOut>> SelectAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> selector)
+        => resultTask.MapAsync(selector);
+
+    /// <summary>
+    /// Selects a new Result from a task result using a synchronous selector.
+    /// This method is intended for LINQ query syntax and delegates to MapAsync.
+    /// </summary>
+    /// <typeparam name="TValueOut">The type of the value returned by the selector.</typeparam>
+    /// <param name="resultTask">The task that produces the source Result.</param>
+    /// <param name="selector">The mapping function.</param>
+    /// <returns>A task containing the selected Result.</returns>
+    public static Task<Result<TValueOut>> SelectAsync<TValueOut>(
+        this Task<Result> resultTask,
+        Func<TValueOut> selector)
+        => resultTask.MapAsync(selector);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Select.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Select.ValueTask.Left.cs
@@ -1,0 +1,31 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Selects a new Result from a ValueTask result using a synchronous selector.
+    /// This method is intended for LINQ query syntax and delegates to MapAsync.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the source Result.</typeparam>
+    /// <typeparam name="TValueOut">The type of the value returned by the selector.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the source Result.</param>
+    /// <param name="selector">The mapping function.</param>
+    /// <returns>A ValueTask containing the selected Result.</returns>
+    public static ValueTask<Result<TValueOut>> SelectAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> selector)
+        => resultTask.MapAsync(selector);
+
+    /// <summary>
+    /// Selects a new Result from a ValueTask result using a synchronous selector.
+    /// This method is intended for LINQ query syntax and delegates to MapAsync.
+    /// </summary>
+    /// <typeparam name="TValueOut">The type of the value returned by the selector.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the source Result.</param>
+    /// <param name="selector">The mapping function.</param>
+    /// <returns>A ValueTask containing the selected Result.</returns>
+    public static ValueTask<Result<TValueOut>> SelectAsync<TValueOut>(
+        this ValueTask<Result> resultTask,
+        Func<TValueOut> selector)
+        => resultTask.MapAsync(selector);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Select.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Select.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Selects a new Result from the current result.
+    /// This method is intended for LINQ query syntax and delegates to Map.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the source Result.</typeparam>
+    /// <typeparam name="TValueOut">The type of the value returned by the selector.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="selector">The mapping function.</param>
+    /// <returns>A new Result containing the selected value or the original errors.</returns>
+    public static Result<TValueOut> Select<TValue, TValueOut>(this Result<TValue> result, Func<TValue, TValueOut> selector)
+        => result.Map(selector);
+
+    /// <summary>
+    /// Selects a new Result from the current result.
+    /// This method is intended for LINQ query syntax and delegates to Map.
+    /// </summary>
+    /// <typeparam name="TValueOut">The type of the value returned by the selector.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="selector">The mapping function.</param>
+    /// <returns>A new Result containing the selected value or the original errors.</returns>
+    public static Result<TValueOut> Select<TValueOut>(this Result result, Func<TValueOut> selector)
+        => result.Map(selector);
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.Base.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class SelectTestsBase : TestBase
+{
+    protected class TValueSelected
+    {
+        public static readonly TValueSelected Value = new();
+    }
+
+    protected TValueSelected SelectFunc()
+    {
+        FuncExecuted = true;
+        return TValueSelected.Value;
+    }
+
+    protected TValueSelected SelectFunc(TValue value)
+    {
+        FuncExecuted = true;
+        return TValueSelected.Value;
+    }
+
+    protected void AssertFailure(Result<TValueSelected> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Errors.Should().Contain(e => e.Message == ErrorMessage);
+    }
+
+    protected void AssertSuccess(Result<TValueSelected> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        FuncExecuted.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValueSelected.Value);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.Task.Left.cs
@@ -1,0 +1,32 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public class SelectTestsTaskLeft : SelectTestsBase
+{
+    [Fact]
+    public async Task SelectTaskLeftReturnsFailureAndDoesNotExecuteSelector()
+    {
+        var output = await TaskFailResultAsync().SelectAsync(SelectFunc);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectTaskLeftProjectsNewResult()
+    {
+        var output = await TaskOkResultAsync().SelectAsync(SelectFunc);
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public async Task SelectTaskLeftTReturnsFailureAndDoesNotExecuteSelector()
+    {
+        var output = await TaskFailResultTAsync().SelectAsync(SelectFunc);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectTaskLeftTProjectsNewResult()
+    {
+        var output = await TaskOkResultTAsync().SelectAsync(SelectFunc);
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.ValueTask.Left.cs
@@ -1,0 +1,32 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public class SelectTestsValueTaskLeft : SelectTestsBase
+{
+    [Fact]
+    public async Task SelectValueTaskLeftReturnsFailureAndDoesNotExecuteSelector()
+    {
+        var output = await ValueTaskFailResultAsync().SelectAsync(SelectFunc);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectValueTaskLeftProjectsNewResult()
+    {
+        var output = await ValueTaskOkResultAsync().SelectAsync(SelectFunc);
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public async Task SelectValueTaskLeftTReturnsFailureAndDoesNotExecuteSelector()
+    {
+        var output = await ValueTaskFailResultTAsync().SelectAsync(SelectFunc);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectValueTaskLeftTProjectsNewResult()
+    {
+        var output = await ValueTaskOkResultTAsync().SelectAsync(SelectFunc);
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectTests.cs
@@ -1,0 +1,32 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectTests : SelectTestsBase
+{
+    [Fact]
+    public void SelectReturnsFailureAndDoesNotExecuteSelector()
+    {
+        var output = Result.Fail(ErrorMessage).Select(SelectFunc);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public void SelectProjectsNewResult()
+    {
+        var output = Result.Ok().Select(SelectFunc);
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public void SelectTReturnsFailureAndDoesNotExecuteSelector()
+    {
+        var output = ResultExtensions.Select(Result.Fail<TValue>(ErrorMessage), SelectFunc);
+        AssertFailure(output);
+    }
+
+    [Fact]
+    public void SelectTProjectsNewResult()
+    {
+        var output = ResultExtensions.Select(Result.Ok(TValue.Value), SelectFunc);
+        AssertSuccess(output);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Select` aliases for sync `Result` and `Result<T>` that delegate to existing `Map`
- add left-operand async aliases following project conventions:
  - `Task<Result*>.SelectAsync(...)`
  - `ValueTask<Result*>.SelectAsync(...)`
- add tests for success/failure short-circuit behavior for sync/task/valuetask variants
- update README with `Select` usage examples

## Validation
- `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- passed on `net8.0`, `net9.0`, `net10.0`

Closes #62