### PR TITLE
feat: add EnsureNotNull method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ Task<Result<string?>> maybeNameTask = GetNameAsync();
 Result<string> requiredFromTask = await maybeNameTask.RequiredAsync("Name is required");
 ```
 
+### EnsureNotNull
+
+`EnsureNotNull` provides CSharpFunctionalExtensions-style naming for non-null validation and follows the same behavior as `Required`.
+
+```csharp
+Result<string?> maybeEmail = Result.Ok<string?>(null);
+Result<string> ensuredEmail = maybeEmail.EnsureNotNull("Email is required");
+
+Task<Result<string?>> maybeEmailTask = GetEmailAsync();
+Result<string> ensuredFromTask = await maybeEmailTask.EnsureNotNullAsync("Email is required");
+```
+
 ### Try
 
 Executes code and converts thrown exceptions to failed `Result` values.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNotNull.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNotNull.Task.Left.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Ensures a successful task reference type result value is non-null.
+    /// </summary>
+    /// <typeparam name="TValue">The reference type contained in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A task containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async Task<Result<TValue>> EnsureNotNullAsync<TValue>(this Task<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.EnsureNotNull(errorMessage);
+    }
+
+    /// <summary>
+    /// Ensures a successful task nullable struct result value has a value.
+    /// </summary>
+    /// <typeparam name="TValue">The value type contained in the nullable Result.</typeparam>
+    /// <param name="resultTask">The task that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A task containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async Task<Result<TValue>> EnsureNotNullAsync<TValue>(this Task<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.EnsureNotNull(errorMessage);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNotNull.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNotNull.ValueTask.Left.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Ensures a successful ValueTask reference type result value is non-null.
+    /// </summary>
+    /// <typeparam name="TValue">The reference type contained in the Result.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A ValueTask containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async ValueTask<Result<TValue>> EnsureNotNullAsync<TValue>(this ValueTask<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.EnsureNotNull(errorMessage);
+    }
+
+    /// <summary>
+    /// Ensures a successful ValueTask nullable struct result value has a value.
+    /// </summary>
+    /// <typeparam name="TValue">The value type contained in the nullable Result.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A ValueTask containing a successful Result with a non-null value or a failed Result.</returns>
+    public static async ValueTask<Result<TValue>> EnsureNotNullAsync<TValue>(this ValueTask<Result<TValue?>> resultTask, string errorMessage)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.EnsureNotNull(errorMessage);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNotNull.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNotNull.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Ensures a successful reference type result value is non-null.
+    /// If the source result is failed, returns a failed Result with the same errors.
+    /// If the source result is successful but the value is null, returns a failed Result with the provided error message.
+    /// </summary>
+    /// <typeparam name="TValue">The reference type contained in the Result.</typeparam>
+    /// <param name="result">The result whose value must be non-null.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A successful Result with a non-null value or a failed Result.</returns>
+    public static Result<TValue> EnsureNotNull<TValue>(this Result<TValue?> result, string errorMessage)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+        return result.Required(errorMessage);
+    }
+
+    /// <summary>
+    /// Ensures a successful nullable struct result value has a value.
+    /// If the source result is failed, returns a failed Result with the same errors.
+    /// If the source result is successful but the value is null, returns a failed Result with the provided error message.
+    /// </summary>
+    /// <typeparam name="TValue">The value type contained in the nullable Result.</typeparam>
+    /// <param name="result">The result whose nullable value must be present.</param>
+    /// <param name="errorMessage">The error message used when the value is null.</param>
+    /// <returns>A successful Result with a non-null value or a failed Result.</returns>
+    public static Result<TValue> EnsureNotNull<TValue>(this Result<TValue?> result, string errorMessage)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(errorMessage);
+        return result.Required(errorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotNullTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotNullTests.Task.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class EnsureNotNullTestsTaskLeft
+{
+    [Fact]
+    public async Task EnsureNotNullTaskLeftReturnsFailureWhenValueIsNull()
+    {
+        var resultTask = Task.FromResult(Result.Ok<string?>(null));
+
+        var output = await resultTask.EnsureNotNullAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public async Task EnsureNotNullTaskLeftReturnsSuccessWhenValueIsNotNull()
+    {
+        var resultTask = Task.FromResult(Result.Ok<string?>("ok"));
+
+        var output = await resultTask.EnsureNotNullAsync("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task EnsureNotNullTaskLeftPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var resultTask = Task.FromResult(Result.Fail<string?>("Source failure"));
+
+        var output = await resultTask.EnsureNotNullAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value is required");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotNullTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotNullTests.ValueTask.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class EnsureNotNullTestsValueTaskLeft
+{
+    [Fact]
+    public async Task EnsureNotNullValueTaskLeftReturnsFailureWhenValueIsNull()
+    {
+        var resultTask = ValueTask.FromResult(Result.Ok<string?>(null));
+
+        var output = await resultTask.EnsureNotNullAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public async Task EnsureNotNullValueTaskLeftReturnsSuccessWhenValueIsNotNull()
+    {
+        var resultTask = ValueTask.FromResult(Result.Ok<string?>("ok"));
+
+        var output = await resultTask.EnsureNotNullAsync("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be("ok");
+    }
+
+    [Fact]
+    public async Task EnsureNotNullValueTaskLeftPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var resultTask = ValueTask.FromResult(Result.Fail<string?>("Source failure"));
+
+        var output = await resultTask.EnsureNotNullAsync("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value is required");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotNullTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotNullTests.cs
@@ -1,0 +1,71 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class EnsureNotNullTests
+{
+    [Fact]
+    public void EnsureNotNullReturnsFailureWhenValueIsNull()
+    {
+        var result = Result.Ok<string?>(null);
+
+        var output = result.EnsureNotNull("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public void EnsureNotNullReturnsSuccessWhenReferenceValueIsNotNull()
+    {
+        const string value = "ok";
+        var result = Result.Ok<string?>(value);
+
+        var output = result.EnsureNotNull("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void EnsureNotNullReturnsSuccessWhenNullableStructHasValue()
+    {
+        var result = Result.Ok<int?>(42);
+
+        var output = result.EnsureNotNull("Value is required");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void EnsureNotNullReturnsFailureWhenNullableStructIsNull()
+    {
+        var result = Result.Ok<int?>(null);
+
+        var output = result.EnsureNotNull("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public void EnsureNotNullPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var result = Result.Fail<string?>("Source failure");
+
+        var output = result.EnsureNotNull("Value is required");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value is required");
+    }
+
+    [Fact]
+    public void EnsureNotNullThrowsWhenErrorMessageIsNull()
+    {
+        var result = Result.Ok<string?>("ok");
+
+        Action act = () => result.EnsureNotNull(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary
- add `EnsureNotNull` for `Result<T?>` (reference and nullable struct variants)
- add left-side async overloads for `Task<Result<T?>>` and `ValueTask<Result<T?>>`
- add unit tests for success/failure, null edge cases, and source failure propagation
- document usage in README

## Verification
- `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- passed on `net8.0`, `net9.0`, and `net10.0`

Closes #50