### PR TITLE
feat(ensure): add EnsureNot method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ var output3 = await Result.Ok(user)
 
 These overloads are available for sync, `Task`, and `ValueTask` variants (left/right/both async forms).
 
+### EnsureNot
+
+`EnsureNot` provides CSharpFunctionalExtensions-style inverted predicate checks for `Result<TValue>`.
+It fails when the predicate evaluates to `true`.
+
+```csharp
+var output = Result.Ok(15)
+    .EnsureNot(x => x > 10, "Value should be less than or equal to 10");
+
+Task<Result<int>> maybeAmountTask = GetAmountAsync();
+Result<int> ensuredFromTask = await maybeAmountTask
+    .EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+```
+
 ### Required
 
 Requires a successful result value to be non-null.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNot.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNot.Task.Left.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Ensures that a condition based on the result value is not met for a successful task result.
+    /// If the condition is met, returns a failed Result with the specified error message.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the Result to ensure.</param>
+    /// <param name="predicate">A function that evaluates the result value and returns true when the condition is met.</param>
+    /// <param name="errorMessage">The error message to use if the condition is met.</param>
+    /// <returns>A task containing a Result that is failed when the condition is met, otherwise the original Result.</returns>
+    public static Task<Result<TValue>> EnsureNotAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, string errorMessage)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        return resultTask.EnsureAsync(value => !predicate(value), errorMessage);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNot.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNot.ValueTask.Left.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Ensures that a condition based on the result value is not met for a successful ValueTask result.
+    /// If the condition is met, returns a failed Result with the specified error message.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="resultTask">The ValueTask that produces the Result to ensure.</param>
+    /// <param name="predicate">A function that evaluates the result value and returns true when the condition is met.</param>
+    /// <param name="errorMessage">The error message to use if the condition is met.</param>
+    /// <returns>A ValueTask containing a Result that is failed when the condition is met, otherwise the original Result.</returns>
+    public static ValueTask<Result<TValue>> EnsureNotAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, string errorMessage)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        return resultTask.EnsureAsync(value => !predicate(value), errorMessage);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNot.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/EnsureNot.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Ensures that a condition based on the result value is not met for a successful Result.
+    /// If the condition is met, returns a failed Result with the specified error message.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value in the Result.</typeparam>
+    /// <param name="result">The Result to ensure.</param>
+    /// <param name="predicate">A function that evaluates the result value and returns true when the condition is met.</param>
+    /// <param name="errorMessage">The error message to use if the condition is met.</param>
+    /// <returns>A Result that is failed when the condition is met, otherwise the original Result.</returns>
+    public static Result<TValue> EnsureNot<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, string errorMessage)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(errorMessage);
+
+        return result.Ensure(value => !predicate(value), errorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotTests.Task.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class EnsureNotTestsTaskLeft
+{
+    [Fact]
+    public async Task EnsureNotTaskLeftReturnsSuccessWhenPredicateIsFalse()
+    {
+        var resultTask = Task.FromResult(Result.Ok(5));
+
+        var output = await resultTask.EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task EnsureNotTaskLeftReturnsFailureWhenPredicateIsTrue()
+    {
+        var resultTask = Task.FromResult(Result.Ok(15));
+
+        var output = await resultTask.EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value should be less than or equal to 10");
+    }
+
+    [Fact]
+    public async Task EnsureNotTaskLeftPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var resultTask = Task.FromResult(Result.Fail<int>("Source failure"));
+
+        var output = await resultTask.EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value should be less than or equal to 10");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotTests.ValueTask.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class EnsureNotTestsValueTaskLeft
+{
+    [Fact]
+    public async Task EnsureNotValueTaskLeftReturnsSuccessWhenPredicateIsFalse()
+    {
+        var resultTask = ValueTask.FromResult(Result.Ok(5));
+
+        var output = await resultTask.EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task EnsureNotValueTaskLeftReturnsFailureWhenPredicateIsTrue()
+    {
+        var resultTask = ValueTask.FromResult(Result.Ok(15));
+
+        var output = await resultTask.EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value should be less than or equal to 10");
+    }
+
+    [Fact]
+    public async Task EnsureNotValueTaskLeftPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var resultTask = ValueTask.FromResult(Result.Fail<int>("Source failure"));
+
+        var output = await resultTask.EnsureNotAsync(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value should be less than or equal to 10");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/EnsureNotTests.cs
@@ -1,0 +1,58 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class EnsureNotTests
+{
+    [Fact]
+    public void EnsureNotReturnsSuccessWhenPredicateIsFalse()
+    {
+        var result = Result.Ok(5);
+
+        var output = result.EnsureNot(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void EnsureNotReturnsFailureWhenPredicateIsTrue()
+    {
+        var result = Result.Ok(15);
+
+        var output = result.EnsureNot(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Value should be less than or equal to 10");
+    }
+
+    [Fact]
+    public void EnsureNotPreservesSourceErrorsWhenSourceIsFailed()
+    {
+        var result = Result.Fail<int>("Source failure");
+
+        var output = result.EnsureNot(x => x > 10, "Value should be less than or equal to 10");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "Source failure");
+        output.Errors.Should().NotContain(x => x.Message == "Value should be less than or equal to 10");
+    }
+
+    [Fact]
+    public void EnsureNotThrowsWhenPredicateIsNull()
+    {
+        var result = Result.Ok(5);
+
+        Action act = () => result.EnsureNot(null!, "Value should be less than or equal to 10");
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void EnsureNotThrowsWhenErrorMessageIsNull()
+    {
+        var result = Result.Ok(5);
+
+        Action act = () => result.EnsureNot(x => x > 10, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- added `EnsureNot` extension for `Result<TValue>` with inverted predicate semantics
- added `EnsureNotAsync` overloads for `Task<Result<TValue>>` and `ValueTask<Result<TValue>>`
- added tests for pass/fail behavior, source-failure passthrough, and null argument edge cases
- updated README with usage examples

## Why
Issue #49 requests `EnsureNot` support aligned with CSharpFunctionalExtensions and async conventions used in this repository.

## How to test
1. Run `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
2. Verify tests pass for `net8.0`, `net9.0`, `net10.0`

## Risks
- API surface extension only; behavior delegates to existing `Ensure`/`EnsureAsync` paths to minimize divergence.

Closes #49