### PR TITLE
feat(of): add Of and OfAsync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ var loadResult = await ResultExtensions.TryAsync(
     ex => $"Load failed: {ex.Message}");
 ```
 
+### Of
+
+Creates successful results from values and value-producing delegates.
+Unlike `Try`, exceptions are not converted to failure results and are propagated to the caller.
+
+```csharp
+var fromValue = ResultExtensions.Of(42);
+
+var fromFunc = ResultExtensions.Of(() => ComputeValue());
+
+var fromTask = await ResultExtensions.OfAsync(repository.GetByIdAsync(id));
+
+var fromValueTask = await ResultExtensions.OfAsync(GetValueValueTaskAsync);
+```
+
 ### Check
 
 Executes a function only if the Result is successful, acting as a validation step in a chain.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Of.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Of.Task.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Creates a successful Result containing the value produced by the specified task.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="valueTask">The task that produces the value.</param>
+    /// <returns>A successful Result containing the resolved value.</returns>
+    public static async Task<Result<TValue>> OfAsync<TValue>(Task<TValue> valueTask)
+    {
+        ArgumentNullException.ThrowIfNull(valueTask);
+
+        var value = await valueTask.ConfigureAwait(false);
+
+        return Result.Ok(value);
+    }
+
+    /// <summary>
+    /// Creates a successful Result containing the value produced by the specified asynchronous function.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="func">The asynchronous function that produces the value.</param>
+    /// <returns>A successful Result containing the resolved value.</returns>
+    public static async Task<Result<TValue>> OfAsync<TValue>(Func<Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var value = await func().ConfigureAwait(false);
+
+        return Result.Ok(value);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Of.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Of.ValueTask.cs
@@ -1,0 +1,32 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Creates a successful Result containing the value produced by the specified value task.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="valueTask">The value task that produces the value.</param>
+    /// <returns>A successful Result containing the resolved value.</returns>
+    public static async ValueTask<Result<TValue>> OfAsync<TValue>(ValueTask<TValue> valueTask)
+    {
+        var value = await valueTask.ConfigureAwait(false);
+
+        return Result.Ok(value);
+    }
+
+    /// <summary>
+    /// Creates a successful Result containing the value produced by the specified asynchronous value-task function.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="func">The asynchronous value-task function that produces the value.</param>
+    /// <returns>A successful Result containing the resolved value.</returns>
+    public static async ValueTask<Result<TValue>> OfAsync<TValue>(Func<ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var value = await func().ConfigureAwait(false);
+
+        return Result.Ok(value);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Of.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Of.cs
@@ -1,0 +1,25 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Creates a successful Result containing the specified value.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="value">The value to wrap.</param>
+    /// <returns>A successful Result containing <paramref name="value" />.</returns>
+    public static Result<TValue> Of<TValue>(TValue value) => Result.Ok(value);
+
+    /// <summary>
+    /// Creates a successful Result containing the value returned by the specified function.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="func">The function that produces the value.</param>
+    /// <returns>A successful Result containing the returned value.</returns>
+    public static Result<TValue> Of<TValue>(Func<TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return Result.Ok(func());
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.Base.cs
@@ -1,0 +1,20 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class OfTestsBase : TestBase
+{
+    protected const string ExceptionMessage = "Of Exception Message";
+
+    protected static TValue SuccessFunc() => TValue.Value;
+
+    protected static TValue FailFunc() => throw new InvalidOperationException(ExceptionMessage);
+
+    protected static Task<TValue> SuccessTask() => Task.FromResult(TValue.Value);
+
+    protected static Task<TValue> FailTask() => Task.FromException<TValue>(new InvalidOperationException(ExceptionMessage));
+
+    protected static ValueTask<TValue> SuccessValueTask() => ValueTask.FromResult(TValue.Value);
+
+    protected static ValueTask<TValue> FailValueTask() => ValueTask.FromException<TValue>(new InvalidOperationException(ExceptionMessage));
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.Task.cs
@@ -1,0 +1,54 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OfTestsTask : OfTestsBase
+{
+    [Fact]
+    public async Task OfAsyncTaskExpectedResultOkWithValue()
+    {
+        var output = await ResultExtensions.OfAsync(SuccessTask());
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task OfAsyncTaskIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.OfAsync((Task<TValue>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task OfAsyncTaskThrowsExpectedException()
+    {
+        var action = async () => await ResultExtensions.OfAsync(FailTask());
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage(ExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OfAsyncTaskFuncExpectedResultOkWithValue()
+    {
+        var output = await ResultExtensions.OfAsync(SuccessTask);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task OfAsyncTaskFuncIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.OfAsync((Func<Task<TValue>>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task OfAsyncTaskFuncThrowsExpectedException()
+    {
+        var action = async () => await ResultExtensions.OfAsync(FailTask);
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage(ExceptionMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.ValueTask.cs
@@ -1,0 +1,46 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OfTestsValueTask : OfTestsBase
+{
+    [Fact]
+    public async Task OfAsyncValueTaskExpectedResultOkWithValue()
+    {
+        var output = await ResultExtensions.OfAsync(SuccessValueTask());
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task OfAsyncValueTaskThrowsExpectedException()
+    {
+        var action = async () => await ResultExtensions.OfAsync(FailValueTask());
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage(ExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OfAsyncValueTaskFuncExpectedResultOkWithValue()
+    {
+        var output = await ResultExtensions.OfAsync(SuccessValueTask);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task OfAsyncValueTaskFuncIsNullExpectedThrowArgumentNullException()
+    {
+        var action = async () => await ResultExtensions.OfAsync((Func<ValueTask<TValue>>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task OfAsyncValueTaskFuncThrowsExpectedException()
+    {
+        var action = async () => await ResultExtensions.OfAsync(FailValueTask);
+
+        await action.Should().ThrowAsync<InvalidOperationException>().WithMessage(ExceptionMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OfTests.cs
@@ -1,0 +1,47 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OfTests : OfTestsBase
+{
+    [Fact]
+    public void OfValueExpectedResultOkWithValue()
+    {
+        var output = ResultExtensions.Of(TValue.Value);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public void OfNullableValueExpectedResultOkWithNull()
+    {
+        var output = ResultExtensions.Of((string?)null);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public void OfFuncExpectedResultOkWithValue()
+    {
+        var output = ResultExtensions.Of(SuccessFunc);
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public void OfFuncIsNullExpectedThrowArgumentNullException()
+    {
+        var action = () => ResultExtensions.Of((Func<TValue>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void OfFuncThrowsExpectedException()
+    {
+        var action = () => ResultExtensions.Of(FailFunc);
+
+        action.Should().Throw<InvalidOperationException>().WithMessage(ExceptionMessage);
+    }
+}


### PR DESCRIPTION
## What
- Add `ResultExtensions.Of<T>(TValue)` and `ResultExtensions.Of<T>(Func<TValue>)`
- Add async overloads:
  - `OfAsync(Task<TValue>)`
  - `OfAsync(Func<Task<TValue>>)`
  - `OfAsync(ValueTask<TValue>)`
  - `OfAsync(Func<ValueTask<TValue>>)`
- Add dedicated unit tests for sync/Task/ValueTask overloads, including null-argument and exception-propagation edge cases
- Update README with an `Of` section and examples

## Why
Issue #58 requests CSharpFunctionalExtensions-style `Of` support with async overloads and tests/docs updates.

## How to test
- Run: `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- Expected: all tests pass for `net8.0`, `net9.0`, `net10.0`

## Risks
- `Of` intentionally propagates exceptions from delegates/tasks (does not convert to failed results). This is documented in README to avoid confusion with `Try`/`TryAsync`.

Closes #58