### PR TITLE
feat(selectmany): add SelectMany and async overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ public Task<Result<int>> GetNumberAsync()
 var output2 = await GetNumberAsync().SelectAsync(v => v + 1);
 ```
 
+### SelectMany
+
+LINQ-friendly alias composition for `Bind` + `Map`.
+Supports query syntax projections while preserving failure short-circuit behavior.
+
+```csharp
+var output =
+    from user in Result.Ok(currentUser)
+    from account in GetAccount(user.Id)
+    select new UserAccountDto(user, account);
+
+var asyncOutput = await GetUserAsync()
+    .SelectManyAsync(GetAccountAsync, (user, account) => new UserAccountDto(user, account));
+```
+
 ## Example
 
 ```csharp

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.Task.Left.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Projects each successful task Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="resultTask">The task producing the source Result.</param>
+    /// <param name="func">Function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A task containing the projected Result.</returns>
+    public static async Task<Result<TValueOut>> SelectManyAsync<TValue, TValueBind, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Result<TValueBind>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.SelectMany(func, project);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.Task.Right.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously projects each successful Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="func">Asynchronous function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A task containing the projected Result.</returns>
+    public static async Task<Result<TValueOut>> SelectManyAsync<TValue, TValueBind, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Task<Result<TValueBind>>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValueOut>(result.Errors);
+        }
+
+        var value = result.Value;
+        var bindResult = await func(value).ConfigureAwait(false);
+
+        return bindResult.IsFailed
+            ? Result.Fail<TValueOut>(bindResult.Errors)
+            : Result.Ok(project(value, bindResult.Value));
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.Task.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously projects each successful task Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="resultTask">The task producing the source Result.</param>
+    /// <param name="func">Asynchronous function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A task containing the projected Result.</returns>
+    public static async Task<Result<TValueOut>> SelectManyAsync<TValue, TValueBind, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Task<Result<TValueBind>>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.SelectManyAsync(func, project).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.ValueTask.Left.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Projects each successful ValueTask Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="resultTask">The ValueTask producing the source Result.</param>
+    /// <param name="func">Function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A ValueTask containing the projected Result.</returns>
+    public static async ValueTask<Result<TValueOut>> SelectManyAsync<TValue, TValueBind, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Result<TValueBind>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.SelectMany(func, project);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.ValueTask.Right.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously projects each successful Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="func">Asynchronous function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A ValueTask containing the projected Result.</returns>
+    public static async ValueTask<Result<TValueOut>> SelectManyAsync<TValue, TValueBind, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, ValueTask<Result<TValueBind>>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValueOut>(result.Errors);
+        }
+
+        var value = result.Value;
+        var bindResult = await func(value).ConfigureAwait(false);
+
+        return bindResult.IsFailed
+            ? Result.Fail<TValueOut>(bindResult.Errors)
+            : Result.Ok(project(value, bindResult.Value));
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.ValueTask.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously projects each successful ValueTask Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="resultTask">The ValueTask producing the source Result.</param>
+    /// <param name="func">Asynchronous function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A ValueTask containing the projected Result.</returns>
+    public static async ValueTask<Result<TValueOut>> SelectManyAsync<TValue, TValueBind, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<Result<TValueBind>>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.SelectManyAsync(func, project).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/SelectMany.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Projects each successful Result value to another Result and combines both values.
+    /// This method is intended for LINQ query syntax.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueBind">The bound value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="func">Function that binds the source value to another Result.</param>
+    /// <param name="project">Function that combines source and bound values.</param>
+    /// <returns>A Result containing the projected value, or failure errors from source/bind.</returns>
+    public static Result<TValueOut> SelectMany<TValue, TValueBind, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Result<TValueBind>> func,
+        Func<TValue, TValueBind, TValueOut> project)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+        ArgumentNullException.ThrowIfNull(project);
+
+        return result.Bind(value => func(value).Map(bindValue => project(value, bindValue)));
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Base.cs
@@ -1,0 +1,86 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class SelectManyTestsBase : TestBase
+{
+    protected const string BindErrorMessage = "Bind Error Message";
+
+    protected bool ProjectExecuted { get; set; }
+
+    protected class TValueBind
+    {
+        public static readonly TValueBind Value = new();
+    }
+
+    protected class TValueSelectMany
+    {
+        public static readonly TValueSelectMany Value = new();
+    }
+
+    protected Result<TValueBind> BindSuccess(TValue _)
+    {
+        FuncExecuted = true;
+        return Result.Ok(TValueBind.Value);
+    }
+
+    protected Result<TValueBind> BindFailure(TValue _)
+    {
+        FuncExecuted = true;
+        return Result.Fail<TValueBind>(BindErrorMessage);
+    }
+
+    protected Task<Result<TValueBind>> BindSuccessTask(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok(TValueBind.Value));
+    }
+
+    protected Task<Result<TValueBind>> BindFailureTask(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Fail<TValueBind>(BindErrorMessage));
+    }
+
+    protected ValueTask<Result<TValueBind>> BindSuccessValueTask(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok(TValueBind.Value));
+    }
+
+    protected ValueTask<Result<TValueBind>> BindFailureValueTask(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Fail<TValueBind>(BindErrorMessage));
+    }
+
+    protected TValueSelectMany Project(TValue _, TValueBind __)
+    {
+        ProjectExecuted = true;
+        return TValueSelectMany.Value;
+    }
+
+    protected void AssertSourceFailure(Result<TValueSelectMany> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == ErrorMessage);
+        FuncExecuted.Should().BeFalse();
+        ProjectExecuted.Should().BeFalse();
+    }
+
+    protected void AssertBindFailure(Result<TValueSelectMany> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == BindErrorMessage);
+        FuncExecuted.Should().BeTrue();
+        ProjectExecuted.Should().BeFalse();
+    }
+
+    protected void AssertSuccess(Result<TValueSelectMany> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValueSelectMany.Value);
+        FuncExecuted.Should().BeTrue();
+        ProjectExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Task.Left.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTestsTaskLeft : SelectManyTestsBase
+{
+    [Fact]
+    public async Task SelectManyTaskLeftReturnsSourceFailure()
+    {
+        var output = await TaskFailResultTAsync().SelectManyAsync(BindSuccess, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyTaskLeftReturnsBindFailure()
+    {
+        var output = await TaskOkResultTAsync().SelectManyAsync(BindFailure, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyTaskLeftReturnsProjectedResult()
+    {
+        var output = await TaskOkResultTAsync().SelectManyAsync(BindSuccess, Project);
+
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Task.Right.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTestsTaskRight : SelectManyTestsBase
+{
+    [Fact]
+    public async Task SelectManyTaskRightReturnsSourceFailure()
+    {
+        var output = await Result.Fail<TValue>(ErrorMessage).SelectManyAsync(BindSuccessTask, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyTaskRightReturnsBindFailure()
+    {
+        var output = await Result.Ok(TValue.Value).SelectManyAsync(BindFailureTask, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyTaskRightReturnsProjectedResult()
+    {
+        var output = await Result.Ok(TValue.Value).SelectManyAsync(BindSuccessTask, Project);
+
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.Task.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTestsTask : SelectManyTestsBase
+{
+    [Fact]
+    public async Task SelectManyTaskReturnsSourceFailure()
+    {
+        var output = await TaskFailResultTAsync().SelectManyAsync(BindSuccessTask, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyTaskReturnsBindFailure()
+    {
+        var output = await TaskOkResultTAsync().SelectManyAsync(BindFailureTask, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyTaskReturnsProjectedResult()
+    {
+        var output = await TaskOkResultTAsync().SelectManyAsync(BindSuccessTask, Project);
+
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.ValueTask.Left.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTestsValueTaskLeft : SelectManyTestsBase
+{
+    [Fact]
+    public async Task SelectManyValueTaskLeftReturnsSourceFailure()
+    {
+        var output = await ValueTaskFailResultTAsync().SelectManyAsync(BindSuccess, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyValueTaskLeftReturnsBindFailure()
+    {
+        var output = await ValueTaskOkResultTAsync().SelectManyAsync(BindFailure, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyValueTaskLeftReturnsProjectedResult()
+    {
+        var output = await ValueTaskOkResultTAsync().SelectManyAsync(BindSuccess, Project);
+
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.ValueTask.Right.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTestsValueTaskRight : SelectManyTestsBase
+{
+    [Fact]
+    public async Task SelectManyValueTaskRightReturnsSourceFailure()
+    {
+        var output = await Result.Fail<TValue>(ErrorMessage).SelectManyAsync(BindSuccessValueTask, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyValueTaskRightReturnsBindFailure()
+    {
+        var output = await Result.Ok(TValue.Value).SelectManyAsync(BindFailureValueTask, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyValueTaskRightReturnsProjectedResult()
+    {
+        var output = await Result.Ok(TValue.Value).SelectManyAsync(BindSuccessValueTask, Project);
+
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.ValueTask.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTestsValueTask : SelectManyTestsBase
+{
+    [Fact]
+    public async Task SelectManyValueTaskReturnsSourceFailure()
+    {
+        var output = await ValueTaskFailResultTAsync().SelectManyAsync(BindSuccessValueTask, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyValueTaskReturnsBindFailure()
+    {
+        var output = await ValueTaskOkResultTAsync().SelectManyAsync(BindFailureValueTask, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public async Task SelectManyValueTaskReturnsProjectedResult()
+    {
+        var output = await ValueTaskOkResultTAsync().SelectManyAsync(BindSuccessValueTask, Project);
+
+        AssertSuccess(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SelectManyTests.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SelectManyTests : SelectManyTestsBase
+{
+    [Fact]
+    public void SelectManyReturnsSourceFailure()
+    {
+        var output = Result.Fail<TValue>(ErrorMessage).SelectMany(BindSuccess, Project);
+
+        AssertSourceFailure(output);
+    }
+
+    [Fact]
+    public void SelectManyReturnsBindFailure()
+    {
+        var output = Result.Ok(TValue.Value).SelectMany(BindFailure, Project);
+
+        AssertBindFailure(output);
+    }
+
+    [Fact]
+    public void SelectManyReturnsProjectedResult()
+    {
+        var output = Result.Ok(TValue.Value).SelectMany(BindSuccess, Project);
+
+        AssertSuccess(output);
+    }
+
+    [Fact]
+    public void SelectManyWithNullBindExpectedThrowArgumentNullException()
+    {
+        var action = () => Result.Ok(TValue.Value).SelectMany((Func<TValue, Result<TValueBind>>)null!, Project);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void SelectManyWithNullProjectExpectedThrowArgumentNullException()
+    {
+        var action = () => Result.Ok(TValue.Value).SelectMany(BindSuccess, (Func<TValue, TValueBind, TValueSelectMany>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- Add LINQ-style `SelectMany` for `Result<T>`
- Add async overloads using project conventions:
  - `SelectManyAsync` for `Task` (left/right/both async forms)
  - `SelectManyAsync` for `ValueTask` (left/right/both async forms)
- Add comprehensive unit tests for sync/Task/ValueTask overloads
- Add README section with `SelectMany` examples (query syntax + async)

## Why
Issue #63 requests CSharpFunctionalExtensions-aligned `SelectMany` support with async overloads, tests, and docs updates.

## How to test
- Run: `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- Expected: all tests pass for `net8.0`, `net9.0`, `net10.0`

## Risks
- API surface expansion for `SelectManyAsync` overloads; behavior remains consistent with existing short-circuiting semantics.

Closes #63