### PR TITLE
feat(checkif): add CheckIf extensions for Result<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ var output = await GetUserAsync()
     .BindAsync(SaveAsync);
 ```
 
+### CheckIf
+
+Conditionally executes `Check` logic for `Result<TValue>`.
+If the condition/predicate is not satisfied, it returns the original result unchanged.
+
+```csharp
+var output = Result.Ok(user)
+    .CheckIf(user.IsActive, u => EnsureUniqueEmailAsync(u.Email));
+
+var output2 = await GetUserAsync()
+    .CheckIfAsync(u => u.IsActive, u => EnsureUniqueEmailAsync(u.Email));
+```
+
 ### Map
 
 Creates a new Result from the return value of a function.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.Task.Left.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(condition, check);
+    }
+
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(condition, check);
+    }
+
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(predicate, check);
+    }
+
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(predicate, check);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.Task.Right.cs
@@ -1,0 +1,46 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        bool condition,
+        Func<Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        return condition ? result.CheckAsync(check) : Task.FromResult(result);
+    }
+
+    public static Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        bool condition,
+        Func<TValue, Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        return condition ? result.CheckAsync(check) : Task.FromResult(result);
+    }
+
+    public static Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        Func<TValue, bool> predicate,
+        Func<Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        return result.IsSuccess && predicate(result.Value) ? result.CheckAsync(check) : Task.FromResult(result);
+    }
+
+    public static Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        Func<TValue, bool> predicate,
+        Func<TValue, Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        return result.IsSuccess && predicate(result.Value) ? result.CheckAsync(check) : Task.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.Task.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(condition, check).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(condition, check).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(predicate, check).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValue>> CheckIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, Task<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(predicate, check).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.ValueTask.Left.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(condition, check);
+    }
+
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(condition, check);
+    }
+
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(predicate, check);
+    }
+
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.CheckIf(predicate, check);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.ValueTask.Right.cs
@@ -1,0 +1,46 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        bool condition,
+        Func<ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        return condition ? result.CheckAsync(check) : ValueTask.FromResult(result);
+    }
+
+    public static ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        bool condition,
+        Func<TValue, ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        return condition ? result.CheckAsync(check) : ValueTask.FromResult(result);
+    }
+
+    public static ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        Func<TValue, bool> predicate,
+        Func<ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        return result.IsSuccess && predicate(result.Value) ? result.CheckAsync(check) : ValueTask.FromResult(result);
+    }
+
+    public static ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this Result<TValue> result,
+        Func<TValue, bool> predicate,
+        Func<TValue, ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        return result.IsSuccess && predicate(result.Value) ? result.CheckAsync(check) : ValueTask.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.ValueTask.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(condition, check).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(condition, check).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(predicate, check).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValue>> CheckIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, ValueTask<Result>> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CheckIfAsync(predicate, check).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CheckIf.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a check when the condition is true.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="condition">Condition that controls check execution.</param>
+    /// <param name="check">Check to execute when condition is true.</param>
+    /// <returns>The original Result when condition is false; otherwise the Check result semantics.</returns>
+    public static Result<TValue> CheckIf<TValue>(this Result<TValue> result, bool condition, Func<Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        return condition ? result.Check(check) : result;
+    }
+
+    /// <summary>
+    /// Executes a check when the condition is true.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="condition">Condition that controls check execution.</param>
+    /// <param name="check">Value-based check to execute when condition is true.</param>
+    /// <returns>The original Result when condition is false; otherwise the Check result semantics.</returns>
+    public static Result<TValue> CheckIf<TValue>(this Result<TValue> result, bool condition, Func<TValue, Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(check);
+
+        return condition ? result.Check(check) : result;
+    }
+
+    /// <summary>
+    /// Executes a check when the predicate is true for the Result value.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="predicate">Predicate that controls check execution.</param>
+    /// <param name="check">Check to execute when predicate is true.</param>
+    /// <returns>The original Result when predicate is false; otherwise the Check result semantics.</returns>
+    public static Result<TValue> CheckIf<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        return result.IsSuccess && predicate(result.Value) ? result.Check(check) : result;
+    }
+
+    /// <summary>
+    /// Executes a check when the predicate is true for the Result value.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The source Result.</param>
+    /// <param name="predicate">Predicate that controls check execution.</param>
+    /// <param name="check">Value-based check to execute when predicate is true.</param>
+    /// <returns>The original Result when predicate is false; otherwise the Check result semantics.</returns>
+    public static Result<TValue> CheckIf<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, Result> check)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(check);
+
+        return result.IsSuccess && predicate(result.Value) ? result.Check(check) : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Base.cs
@@ -1,0 +1,18 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public abstract class CheckIfTestsBase : CheckTestsBase
+{
+    protected bool PredicateExecuted { get; private set; }
+
+    protected bool TruePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Task.Left.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTestsTaskLeft : CheckIfTestsBase
+{
+    [Fact]
+    public async Task CheckIfTaskLeftConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).CheckIfAsync(false, () => OkCheck());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskLeftConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        Result Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return checkResult;
+        }
+
+        var output = await Task.FromResult(result).CheckIfAsync(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskLeftPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).CheckIfAsync(FalsePredicate, () => OkCheck());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskLeftPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await Task.FromResult(result).CheckIfAsync(TruePredicate, value => OkCheck(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Task.Right.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTestsTaskRight : CheckIfTestsBase
+{
+    [Fact]
+    public async Task CheckIfTaskRightConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.CheckIfAsync(false, () => TaskOkCheckAsync());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskRightConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        Task<Result> Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return Task.FromResult(checkResult);
+        }
+
+        var output = await result.CheckIfAsync(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskRightPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.CheckIfAsync(FalsePredicate, () => TaskOkCheckAsync());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskRightPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await result.CheckIfAsync(TruePredicate, value => TaskOkCheckAsync(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.Task.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTestsTask : CheckIfTestsBase
+{
+    [Fact]
+    public async Task CheckIfTaskConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).CheckIfAsync(false, () => TaskOkCheckAsync());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        Task<Result> Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return Task.FromResult(checkResult);
+        }
+
+        var output = await Task.FromResult(result).CheckIfAsync(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).CheckIfAsync(FalsePredicate, () => TaskOkCheckAsync());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfTaskPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await Task.FromResult(result).CheckIfAsync(TruePredicate, value => TaskOkCheckAsync(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.ValueTask.Left.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTestsValueTaskLeft : CheckIfTestsBase
+{
+    [Fact]
+    public async Task CheckIfValueTaskLeftConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(false, () => OkCheck());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskLeftConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        Result Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return checkResult;
+        }
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskLeftPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(FalsePredicate, () => OkCheck());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskLeftPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(TruePredicate, value => OkCheck(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.ValueTask.Right.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTestsValueTaskRight : CheckIfTestsBase
+{
+    [Fact]
+    public async Task CheckIfValueTaskRightConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.CheckIfAsync(false, () => ValueTaskOkCheckAsync());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskRightConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        ValueTask<Result> Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return ValueTask.FromResult(checkResult);
+        }
+
+        var output = await result.CheckIfAsync(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskRightPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.CheckIfAsync(FalsePredicate, () => ValueTaskOkCheckAsync());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskRightPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await result.CheckIfAsync(TruePredicate, value => ValueTaskOkCheckAsync(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.ValueTask.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTestsValueTask : CheckIfTestsBase
+{
+    [Fact]
+    public async Task CheckIfValueTaskConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(false, () => ValueTaskOkCheckAsync());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        ValueTask<Result> Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return ValueTask.FromResult(checkResult);
+        }
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(FalsePredicate, () => ValueTaskOkCheckAsync());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public async Task CheckIfValueTaskPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await new ValueTask<Result<TValue>>(result).CheckIfAsync(TruePredicate, value => ValueTaskOkCheckAsync(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CheckIfTests.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CheckIfTests : CheckIfTestsBase
+{
+    [Fact]
+    public void CheckIfConditionFalseReturnsOriginalResultAndSkipsCheck()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.CheckIf(false, () => OkCheck());
+
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public void CheckIfConditionTrueExecutesCheckAndReturnsFailure()
+    {
+        var result = Result.Ok(TValue.Value);
+        Result? checkResult = null;
+
+        Result Check(TValue value)
+        {
+            FuncExecuted = true;
+            checkResult = Result.Fail(ErrorMessage);
+            return checkResult;
+        }
+
+        var output = result.CheckIf(true, Check);
+
+        FuncExecuted.Should().BeTrue();
+        output.Should().NotBeSameAs(result);
+        AssertFailedWithErrors(output, checkResult!);
+    }
+
+    [Fact]
+    public void CheckIfPredicateFalseSkipsCheckAndReturnsOriginalResult()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.CheckIf(FalsePredicate, () => OkCheck());
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+
+    [Fact]
+    public void CheckIfPredicateOnFailedSourceSkipsPredicateAndCheck()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = result.CheckIf(TruePredicate, value => OkCheck(value));
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        AssertSameInstance(result, output);
+    }
+}


### PR DESCRIPTION
## What
Implemented `CheckIf` for `Result<TValue>` with sync + async overloads following existing project conventions.

## Why
Issue #43 requests `CheckIf` support aligned with CSharpFunctionalExtensions.

## How to test
- Run: `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- Verify tests pass for `net8.0`, `net9.0`, `net10.0`

## Risks
- Low risk; changes are additive and covered by dedicated tests.

Closes #43