### PR TITLE
feat(successif): add SuccessIf APIs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,23 @@ var output3 = await Result.Ok(user)
 
 These overloads are available for sync, `Task`, and `ValueTask` variants (left/right/both async forms).
 
+### SuccessIf
+
+`SuccessIf` provides CSharpFunctionalExtensions-style naming for FluentResults `OkIf` behavior.
+
+```csharp
+var output = ResultExtensions.SuccessIf(amount > 0, "Amount must be positive");
+
+var outputWithValue = ResultExtensions.SuccessIf(
+    () => amount > 0,
+    amount,
+    "Amount must be positive");
+
+var asyncOutput = await ResultExtensions.SuccessIfAsync(
+    async () => await IsAmountValidAsync(amount),
+    "Amount must be positive");
+```
+
 ### EnsureNot
 
 `EnsureNot` provides CSharpFunctionalExtensions-style inverted predicate checks for `Result<TValue>`.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OkIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OkIf.cs
@@ -3,6 +3,54 @@
 public static partial class ResultExtensions
 {
     /// <summary>
+    /// Returns a Result that is successful if the specified condition is true, otherwise failed.
+    /// This method mirrors CSharpFunctionalExtensions naming and delegates to FluentResults semantics.
+    /// </summary>
+    /// <param name="isSuccess">The condition that determines whether the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A successful Result when <paramref name="isSuccess"/> is true; otherwise a failed Result.</returns>
+    public static Result SuccessIf(bool isSuccess, string error) =>
+        isSuccess ? Result.Ok() : Result.Fail(error);
+
+    /// <summary>
+    /// Returns a Result that is successful when the predicate evaluates to true, otherwise failed.
+    /// </summary>
+    /// <param name="predicate">Predicate that determines whether the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A successful Result when the predicate evaluates to true; otherwise a failed Result.</returns>
+    public static Result SuccessIf(Func<bool> predicate, string error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return SuccessIf(predicate(), error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is successful if the specified condition is true, otherwise failed.
+    /// This method mirrors CSharpFunctionalExtensions naming and delegates to FluentResults semantics.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="isSuccess">The condition that determines whether the Result is successful.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A successful Result when <paramref name="isSuccess"/> is true; otherwise a failed Result.</returns>
+    public static Result<TValue> SuccessIf<TValue>(bool isSuccess, TValue value, string error) =>
+        OkIf(isSuccess, error, value);
+
+    /// <summary>
+    /// Returns a Result that is successful when the predicate evaluates to true, otherwise failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="predicate">Predicate that determines whether the Result is successful.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A successful Result when the predicate evaluates to true; otherwise a failed Result.</returns>
+    public static Result<TValue> SuccessIf<TValue>(Func<bool> predicate, TValue value, string error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return SuccessIf(predicate(), value, error);
+    }
+
+    /// <summary>
     /// Returns a Result that is Ok if the specified condition is true, otherwise Fail.
     /// </summary>
     /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
@@ -36,4 +84,78 @@ public static partial class ResultExtensions
     /// <returns>A Task that contains a Result that is Ok if isSuccess is true, otherwise Fail.</returns>
     public static ValueTask<Result<TValue>> OkIfAsync<TValue>(bool isSuccess, string error, TValue value) =>
         ValueTask.FromResult(isSuccess ? Result.Ok(value) : Result.Fail<TValue>(error));
+
+    /// <summary>
+    /// Returns a Result that is successful if the specified condition is true, otherwise failed.
+    /// This method is asynchronous for API consistency with async code paths.
+    /// </summary>
+    /// <param name="isSuccess">The condition that determines whether the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static ValueTask<Result> SuccessIfAsync(bool isSuccess, string error) =>
+        OkIfAsync(isSuccess, error);
+
+    /// <summary>
+    /// Returns a Result that is successful if the specified condition is true, otherwise failed.
+    /// This method is asynchronous for API consistency with async code paths.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="isSuccess">The condition that determines whether the Result is successful.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static ValueTask<Result<TValue>> SuccessIfAsync<TValue>(bool isSuccess, TValue value, string error) =>
+        OkIfAsync(isSuccess, error, value);
+
+    /// <summary>
+    /// Returns a Result that is successful when the Task predicate evaluates to true, otherwise failed.
+    /// </summary>
+    /// <param name="predicate">Asynchronous predicate that determines whether the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result> SuccessIfAsync(Func<Task<bool>> predicate, string error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return await SuccessIfAsync(await predicate(), error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is successful when the Task predicate evaluates to true, otherwise failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="predicate">Asynchronous predicate that determines whether the Result is successful.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result<TValue>> SuccessIfAsync<TValue>(Func<Task<bool>> predicate, TValue value, string error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return await SuccessIfAsync(await predicate(), value, error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is successful when the ValueTask predicate evaluates to true, otherwise failed.
+    /// </summary>
+    /// <param name="predicate">Asynchronous predicate that determines whether the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result> SuccessIfAsync(Func<ValueTask<bool>> predicate, string error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return await SuccessIfAsync(await predicate(), error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is successful when the ValueTask predicate evaluates to true, otherwise failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="predicate">Asynchronous predicate that determines whether the Result is successful.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result<TValue>> SuccessIfAsync<TValue>(Func<ValueTask<bool>> predicate, TValue value, string error)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        return await SuccessIfAsync(await predicate(), value, error);
+    }
 }

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SuccessIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SuccessIfTests.Task.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SuccessIfTestsTask
+{
+    [Fact]
+    public async Task SuccessIfAsyncTaskPredicateReturnsOkWhenPredicateReturnsTrue()
+    {
+        var output = await ResultExtensions.SuccessIfAsync(() => Task.FromResult(true), "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncTaskPredicateReturnsFailWhenPredicateReturnsFalse()
+    {
+        var output = await ResultExtensions.SuccessIfAsync(() => Task.FromResult(false), "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncTaskPredicateWithValueReturnsOkWithValueWhenPredicateReturnsTrue()
+    {
+        var value = new object();
+        var output = await ResultExtensions.SuccessIfAsync(() => Task.FromResult(true), value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncTaskPredicateWithValueReturnsFailWhenPredicateReturnsFalse()
+    {
+        var output = await ResultExtensions.SuccessIfAsync(() => Task.FromResult(false), 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncTaskPredicateThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.SuccessIfAsync((Func<Task<bool>>)null!, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncTaskPredicateWithValueThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.SuccessIfAsync((Func<Task<bool>>)null!, 10, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SuccessIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SuccessIfTests.ValueTask.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SuccessIfTestsValueTask
+{
+    [Fact]
+    public async Task SuccessIfAsyncValueTaskPredicateReturnsOkWhenPredicateReturnsTrue()
+    {
+        var output = await ResultExtensions.SuccessIfAsync(() => ValueTask.FromResult(true), "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncValueTaskPredicateReturnsFailWhenPredicateReturnsFalse()
+    {
+        var output = await ResultExtensions.SuccessIfAsync(() => ValueTask.FromResult(false), "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncValueTaskPredicateWithValueReturnsOkWithValueWhenPredicateReturnsTrue()
+    {
+        var value = new object();
+        var output = await ResultExtensions.SuccessIfAsync(() => ValueTask.FromResult(true), value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncValueTaskPredicateWithValueReturnsFailWhenPredicateReturnsFalse()
+    {
+        var output = await ResultExtensions.SuccessIfAsync(() => ValueTask.FromResult(false), 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncValueTaskPredicateThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.SuccessIfAsync((Func<ValueTask<bool>>)null!, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task SuccessIfAsyncValueTaskPredicateWithValueThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.SuccessIfAsync((Func<ValueTask<bool>>)null!, 10, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SuccessIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/SuccessIfTests.cs
@@ -1,0 +1,92 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class SuccessIfTests
+{
+    [Fact]
+    public void SuccessIfBoolReturnsOkWhenConditionTrue()
+    {
+        var output = ResultExtensions.SuccessIf(true, "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SuccessIfBoolReturnsFailWhenConditionFalse()
+    {
+        var output = ResultExtensions.SuccessIf(false, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void SuccessIfBoolWithValueReturnsOkWithValueWhenConditionTrue()
+    {
+        var value = new object();
+        var output = ResultExtensions.SuccessIf(true, value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public void SuccessIfBoolWithValueReturnsFailWhenConditionFalse()
+    {
+        var output = ResultExtensions.SuccessIf(false, 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void SuccessIfPredicateReturnsOkWhenPredicateReturnsTrue()
+    {
+        var output = ResultExtensions.SuccessIf(() => true, "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SuccessIfPredicateReturnsFailWhenPredicateReturnsFalse()
+    {
+        var output = ResultExtensions.SuccessIf(() => false, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void SuccessIfPredicateWithValueReturnsOkWithValueWhenPredicateReturnsTrue()
+    {
+        var value = new object();
+        var output = ResultExtensions.SuccessIf(() => true, value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public void SuccessIfPredicateWithValueReturnsFailWhenPredicateReturnsFalse()
+    {
+        var output = ResultExtensions.SuccessIf(() => false, 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void SuccessIfPredicateThrowsWhenPredicateIsNull()
+    {
+        var action = () => ResultExtensions.SuccessIf((Func<bool>)null!, "error");
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void SuccessIfPredicateWithValueThrowsWhenPredicateIsNull()
+    {
+        var action = () => ResultExtensions.SuccessIf((Func<bool>)null!, 10, "error");
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Add `SuccessIf` support aligned with CSharpFunctionalExtensions naming and overload patterns.

## Why
Issue #64 requests `SuccessIf` support with async overloads and tests.

## How to test
- Run: `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln`
- Verify all targets pass (`net8.0`, `net9.0`, `net10.0`).

## Risks
- Low risk: implementation delegates to existing FluentResults/`OkIf` semantics.
- New overloads may increase API surface; behavior is covered by dedicated tests.

Closes #64