### PR TITLE
feat: add OnSuccessTry extensions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## What
+- Describe the implementation changes.
+- Keep this focused on behavior and code-level impact.
+
+## Why
+- Link the problem statement and expected outcome.
+- Reference the issue this PR addresses.
+
+## How to test
+- `cd <relevant-directory>`
+- `<run-command-1>`
+- `<run-command-2>`
+- `<run-command-3>`
+
+## Risks
+- List known tradeoffs, limitations, or migration concerns.
+- Mention any follow-up work if needed.
+
+Closes #<issue-number>

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ var loadResult = await ResultExtensions.TryAsync(
     ex => $"Load failed: {ex.Message}");
 ```
 
+### OnSuccessTry
+
+Executes an action/function only for successful results and converts thrown exceptions into failed `Result` values.
+For failed source results, errors are preserved and the delegate is not executed.
+
+```csharp
+var output = Result.Ok()
+    .OnSuccessTry(() => Save(customer));
+
+var outputWithValue = Result.Ok(customer)
+    .OnSuccessTry(c => SendNotification(c));
+
+var asyncOutput = await GetCustomerResultAsync()
+    .OnSuccessTryAsync(async c => await SendNotificationAsync(c));
+```
+
 ### Of
 
 Creates successful results from values and value-producing delegates.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.Task.Left.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the action when the awaited result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="action">Action to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the action via <see cref="Try(Action,Func{Exception,string}?)"/>.</returns>
+    public static async Task<Result> OnSuccessTryAsync(this Task<Result> resultTask, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return result.OnSuccessTry(action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes the action when the awaited result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="action">Action to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the action via <see cref="Try(Action,Func{Exception,string}?)"/>.</returns>
+    public static async Task<Result> OnSuccessTryAsync<TValue>(this Task<Result<TValue>> resultTask, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return result.OnSuccessTry(action, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.Task.Right.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the function when the source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">Function to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the function via <see cref="TryAsync(Func{Task},Func{Exception,string}?)"/>.</returns>
+    public static Task<Result> OnSuccessTryAsync(this Result result, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Task.FromResult(result)
+            : TryAsync(func, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes the function when the source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">Function to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the function via <see cref="TryAsync(Func{Task},Func{Exception,string}?)"/>.</returns>
+    public static Task<Result> OnSuccessTryAsync<TValue>(this Result<TValue> result, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Task.FromResult(result.ToResult())
+            : TryAsync(() => func(result.Value), errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.Task.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the function when the awaited source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">Function to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the function via <see cref="TryAsync(Func{Task},Func{Exception,string}?)"/>.</returns>
+    public static async Task<Result> OnSuccessTryAsync(this Task<Result> resultTask, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return await result.OnSuccessTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes the function when the awaited source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">Function to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the function via <see cref="TryAsync(Func{Task},Func{Exception,string}?)"/>.</returns>
+    public static async Task<Result> OnSuccessTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return await result.OnSuccessTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.ValueTask.Left.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the action when the awaited result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="action">Action to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the action via <see cref="Try(Action,Func{Exception,string}?)"/>.</returns>
+    public static async ValueTask<Result> OnSuccessTryAsync(this ValueTask<Result> resultTask, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return result.OnSuccessTry(action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes the action when the awaited result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="action">Action to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the action via <see cref="Try(Action,Func{Exception,string}?)"/>.</returns>
+    public static async ValueTask<Result> OnSuccessTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return result.OnSuccessTry(action, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.ValueTask.Right.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the function when the source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">Function to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the function via <see cref="TryAsync(Func{ValueTask},Func{Exception,string}?)"/>.</returns>
+    public static ValueTask<Result> OnSuccessTryAsync(this Result result, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? ValueTask.FromResult(result)
+            : TryAsync(func, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes the function when the source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">Function to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the function via <see cref="TryAsync(Func{ValueTask},Func{Exception,string}?)"/>.</returns>
+    public static ValueTask<Result> OnSuccessTryAsync<TValue>(this Result<TValue> result, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? ValueTask.FromResult(result.ToResult())
+            : TryAsync(() => func(result.Value), errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.ValueTask.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the function when the awaited source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">Function to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the function via <see cref="TryAsync(Func{ValueTask},Func{Exception,string}?)"/>.</returns>
+    public static async ValueTask<Result> OnSuccessTryAsync(this ValueTask<Result> resultTask, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return await result.OnSuccessTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes the function when the awaited source result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">Function to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the function via <see cref="TryAsync(Func{ValueTask},Func{Exception,string}?)"/>.</returns>
+    public static async ValueTask<Result> OnSuccessTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+
+        return await result.OnSuccessTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnSuccessTry.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes the action when the result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="action">Action to execute when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result, or the outcome of executing the action via <see cref="Try(Action,Func{Exception,string}?)"/>.</returns>
+    public static Result OnSuccessTry(this Result result, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return result.IsFailed
+            ? result
+            : Try(action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes the action when the result is successful and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">Type of the source result value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="action">Action to execute with the source value when the source result is successful.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original failed result converted to <see cref="Result"/>, or the outcome of executing the action via <see cref="Try(Action,Func{Exception,string}?)"/>.</returns>
+    public static Result OnSuccessTry<TValue>(this Result<TValue> result, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return result.IsFailed
+            ? result.ToResult()
+            : Try(() => action(result.Value), errorHandler);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Base.cs
@@ -1,0 +1,82 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class OnSuccessTryTestsBase : TestBase
+{
+    protected const string TryExceptionMessage = "OnSuccessTry Exception Message";
+    protected const string CustomErrorMessage = "Custom OnSuccessTry Error Message";
+
+    private bool actionExecuted;
+
+    protected void ActionEmpty() => actionExecuted = true;
+    protected void ActionWithValue(TValue _) => actionExecuted = true;
+
+    protected void ThrowAction()
+    {
+        actionExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected void ThrowActionWithValue(TValue _)
+    {
+        actionExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Task TaskActionEmptyAsync()
+    {
+        actionExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    protected Task TaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    protected Task ThrowTaskActionAsync()
+    {
+        actionExecuted = true;
+        return Task.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected Task ThrowTaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return Task.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask ValueTaskActionEmptyAsync()
+    {
+        actionExecuted = true;
+        return ValueTask.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return ValueTask.CompletedTask;
+    }
+
+    protected ValueTask ThrowValueTaskActionAsync()
+    {
+        actionExecuted = true;
+        return ValueTask.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask ThrowValueTaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return ValueTask.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected static string CustomErrorHandler(Exception _) => CustomErrorMessage;
+
+    protected void AssertState(Result output, bool expectedActionExecuted, bool expectedSuccess)
+    {
+        actionExecuted.Should().Be(expectedActionExecuted);
+        output.IsSuccess.Should().Be(expectedSuccess);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Task.Left.cs
@@ -1,0 +1,47 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTestsTaskLeft : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncExecutesActionOnlyWhenTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage).AsTask();
+
+        var output = await resultTask.OnSuccessTryAsync(ActionEmpty);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncTExecutesActionOnlyWhenTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value).AsTask();
+
+        var output = await resultTask.OnSuccessTryAsync(ActionWithValue);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .OnSuccessTryAsync(ThrowAction, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncThrowsWhenActionIsNull()
+    {
+        var action = async () => await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .OnSuccessTryAsync(null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Task.Right.cs
@@ -1,0 +1,54 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTestsTaskRight : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncExecutesTaskFunctionOnlyWhenResultIsSuccessful(bool isSuccess)
+    {
+        var result = Result.OkIf(isSuccess, ErrorMessage);
+
+        var output = await result.OnSuccessTryAsync(TaskActionEmptyAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncTExecutesTaskFunctionOnlyWhenResultIsSuccessful(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIf(isSuccess, ErrorMessage, TValue.Value);
+
+        var output = await result.OnSuccessTryAsync(TaskActionWithValueAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await Result.Ok().OnSuccessTryAsync(ThrowTaskActionAsync);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsTaskExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok().OnSuccessTryAsync(ThrowTaskActionAsync, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncThrowsWhenFunctionIsNull()
+    {
+        var action = async () => await Result.Ok().OnSuccessTryAsync((Func<Task>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.Task.cs
@@ -1,0 +1,57 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTestsTask : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncExecutesTaskFunctionOnlyWhenTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage).AsTask();
+
+        var output = await resultTask.OnSuccessTryAsync(TaskActionEmptyAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncTExecutesTaskFunctionOnlyWhenTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value).AsTask();
+
+        var output = await resultTask.OnSuccessTryAsync(TaskActionWithValueAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .OnSuccessTryAsync(ThrowTaskActionAsync);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsTaskExceptionToFailureWithCustomError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .OnSuccessTryAsync(ThrowTaskActionAsync, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncThrowsWhenFunctionIsNull()
+    {
+        var action = async () => await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .OnSuccessTryAsync((Func<Task>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.ValueTask.Left.cs
@@ -1,0 +1,57 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTestsValueTaskLeft : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncExecutesActionOnlyWhenValueTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage);
+
+        var output = await resultTask.OnSuccessTryAsync(ActionEmpty);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncTExecutesActionOnlyWhenValueTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value);
+
+        var output = await resultTask.OnSuccessTryAsync(ActionWithValue);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .OnSuccessTryAsync(ThrowAction);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .OnSuccessTryAsync(ThrowAction, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncThrowsWhenActionIsNull()
+    {
+        var action = async () => await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .OnSuccessTryAsync((Action)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.ValueTask.Right.cs
@@ -1,0 +1,54 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTestsValueTaskRight : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncExecutesValueTaskFunctionOnlyWhenResultIsSuccessful(bool isSuccess)
+    {
+        var result = Result.OkIf(isSuccess, ErrorMessage);
+
+        var output = await result.OnSuccessTryAsync(ValueTaskActionEmptyAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncTExecutesValueTaskFunctionOnlyWhenResultIsSuccessful(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIf(isSuccess, ErrorMessage, TValue.Value);
+
+        var output = await result.OnSuccessTryAsync(ValueTaskActionWithValueAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsValueTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await Result.Ok().OnSuccessTryAsync(ThrowValueTaskActionAsync);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsValueTaskExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok().OnSuccessTryAsync(ThrowValueTaskActionAsync, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncThrowsWhenFunctionIsNull()
+    {
+        var action = async () => await Result.Ok().OnSuccessTryAsync((Func<ValueTask>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.ValueTask.cs
@@ -1,0 +1,57 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTestsValueTask : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncExecutesValueTaskFunctionOnlyWhenValueTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage);
+
+        var output = await resultTask.OnSuccessTryAsync(ValueTaskActionEmptyAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OnSuccessTryAsyncTExecutesValueTaskFunctionOnlyWhenValueTaskResultIsSuccessful(bool isSuccess)
+    {
+        var resultTask = ResultExtensions.OkIfAsync(isSuccess, ErrorMessage, TValue.Value);
+
+        var output = await resultTask.OnSuccessTryAsync(ValueTaskActionWithValueAsync);
+
+        AssertState(output, isSuccess, isSuccess);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsValueTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .OnSuccessTryAsync(ThrowValueTaskActionAsync);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncConvertsValueTaskExceptionToFailureWithCustomError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .OnSuccessTryAsync(ThrowValueTaskActionAsync, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public async Task OnSuccessTryAsyncThrowsWhenFunctionIsNull()
+    {
+        var action = async () => await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .OnSuccessTryAsync((Func<ValueTask>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnSuccessTryTests.cs
@@ -1,0 +1,88 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnSuccessTryTests : OnSuccessTryTestsBase
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OnSuccessTryExecutesActionOnlyWhenResultIsSuccessful(bool isSuccess)
+    {
+        var result = Result.OkIf(isSuccess, ErrorMessage);
+
+        var output = result.OnSuccessTry(ActionEmpty);
+
+        AssertState(output, isSuccess, isSuccess);
+        if (!isSuccess)
+        {
+            output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OnSuccessTryTExecutesActionOnlyWhenResultIsSuccessful(bool isSuccess)
+    {
+        var result = ResultExtensions.OkIf(isSuccess, ErrorMessage, TValue.Value);
+
+        var output = result.OnSuccessTry(ActionWithValue);
+
+        AssertState(output, isSuccess, isSuccess);
+        if (!isSuccess)
+        {
+            output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        }
+    }
+
+    [Fact]
+    public void OnSuccessTryConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok().OnSuccessTry(ThrowAction);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public void OnSuccessTryConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok().OnSuccessTry(ThrowAction, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public void OnSuccessTryTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok(TValue.Value).OnSuccessTry(ThrowActionWithValue);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+    }
+
+    [Fact]
+    public void OnSuccessTryTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok(TValue.Value).OnSuccessTry(ThrowActionWithValue, CustomErrorHandler);
+
+        AssertState(output, true, false);
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+    }
+
+    [Fact]
+    public void OnSuccessTryThrowsWhenActionIsNull()
+    {
+        var action = () => Result.Ok().OnSuccessTry(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void OnSuccessTryTThrowsWhenActionIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).OnSuccessTry(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- Added `OnSuccessTry` sync overloads for `Result` and `Result<TValue>`.
- Added async overload families for `Task` and `ValueTask` (left/right/both async forms) following project conventions.
- Added full unit test coverage for sync, `Task`, and `ValueTask` variants, including success/failure short-circuit, exception mapping, and null-guard cases.
- Updated README with a new `OnSuccessTry` section and usage examples.
- Added `.github/pull_request_template.md`.

## Why
- Implements issue #60 (`Add OnSuccessTry method`) to align the library API with CSharpFunctionalExtensions-style functionality while preserving FluentResults semantics.

## How to test
- `dotnet test`

## Risks
- API surface expansion adds new overloads, so overload resolution should be monitored for ambiguous call sites with `null` delegates (guards are covered by tests).
- No behavior changes to existing methods; only additive changes.

Closes #60