### PR TITLE
feat: add FailureIf extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ var asyncOutput = await ResultExtensions.SuccessIfAsync(
     "Amount must be positive");
 ```
 
+### FailureIf
+
+`FailureIf` provides CSharpFunctionalExtensions-style inverted condition naming.
+It fails when the condition/predicate is `true`.
+
+```csharp
+var output = ResultExtensions.FailureIf(amount <= 0, "Amount must be positive");
+
+var outputWithValue = ResultExtensions.FailureIf(
+    () => amount <= 0,
+    amount,
+    "Amount must be positive");
+
+var asyncOutput = await ResultExtensions.FailureIfAsync(
+    async () => await IsAmountInvalidAsync(amount),
+    "Amount must be positive");
+```
+
 ### EnsureNot
 
 `EnsureNot` provides CSharpFunctionalExtensions-style inverted predicate checks for `Result<TValue>`.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FailureIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FailureIf.cs
@@ -1,0 +1,126 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns a Result that is failed if the specified condition is true, otherwise successful.
+    /// This method mirrors CSharpFunctionalExtensions naming and delegates to FluentResults semantics.
+    /// </summary>
+    /// <param name="isFailure">The condition that determines whether the Result is failed.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A failed Result when <paramref name="isFailure"/> is true; otherwise a successful Result.</returns>
+    public static Result FailureIf(bool isFailure, string error) =>
+        SuccessIf(!isFailure, error);
+
+    /// <summary>
+    /// Returns a Result that is failed when the predicate evaluates to true, otherwise successful.
+    /// </summary>
+    /// <param name="failurePredicate">Predicate that determines whether the Result is failed.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A failed Result when the predicate evaluates to true; otherwise a successful Result.</returns>
+    public static Result FailureIf(Func<bool> failurePredicate, string error)
+    {
+        ArgumentNullException.ThrowIfNull(failurePredicate);
+        return FailureIf(failurePredicate(), error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is failed if the specified condition is true, otherwise successful.
+    /// This method mirrors CSharpFunctionalExtensions naming and delegates to FluentResults semantics.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="isFailure">The condition that determines whether the Result is failed.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A failed Result when <paramref name="isFailure"/> is true; otherwise a successful Result.</returns>
+    public static Result<TValue> FailureIf<TValue>(bool isFailure, TValue value, string error) =>
+        SuccessIf(!isFailure, value, error);
+
+    /// <summary>
+    /// Returns a Result that is failed when the predicate evaluates to true, otherwise successful.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="failurePredicate">Predicate that determines whether the Result is failed.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A failed Result when the predicate evaluates to true; otherwise a successful Result.</returns>
+    public static Result<TValue> FailureIf<TValue>(Func<bool> failurePredicate, TValue value, string error)
+    {
+        ArgumentNullException.ThrowIfNull(failurePredicate);
+        return FailureIf(failurePredicate(), value, error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is failed if the specified condition is true, otherwise successful.
+    /// This method is asynchronous for API consistency with async code paths.
+    /// </summary>
+    /// <param name="isFailure">The condition that determines whether the Result is failed.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static ValueTask<Result> FailureIfAsync(bool isFailure, string error) =>
+        SuccessIfAsync(!isFailure, error);
+
+    /// <summary>
+    /// Returns a Result that is failed if the specified condition is true, otherwise successful.
+    /// This method is asynchronous for API consistency with async code paths.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="isFailure">The condition that determines whether the Result is failed.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static ValueTask<Result<TValue>> FailureIfAsync<TValue>(bool isFailure, TValue value, string error) =>
+        SuccessIfAsync(!isFailure, value, error);
+
+    /// <summary>
+    /// Returns a Result that is failed when the Task predicate evaluates to true, otherwise successful.
+    /// </summary>
+    /// <param name="failurePredicate">Asynchronous predicate that determines whether the Result is failed.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result> FailureIfAsync(Func<Task<bool>> failurePredicate, string error)
+    {
+        ArgumentNullException.ThrowIfNull(failurePredicate);
+        return await FailureIfAsync(await failurePredicate(), error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is failed when the Task predicate evaluates to true, otherwise successful.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="failurePredicate">Asynchronous predicate that determines whether the Result is failed.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result<TValue>> FailureIfAsync<TValue>(Func<Task<bool>> failurePredicate, TValue value, string error)
+    {
+        ArgumentNullException.ThrowIfNull(failurePredicate);
+        return await FailureIfAsync(await failurePredicate(), value, error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is failed when the ValueTask predicate evaluates to true, otherwise successful.
+    /// </summary>
+    /// <param name="failurePredicate">Asynchronous predicate that determines whether the Result is failed.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result> FailureIfAsync(Func<ValueTask<bool>> failurePredicate, string error)
+    {
+        ArgumentNullException.ThrowIfNull(failurePredicate);
+        return await FailureIfAsync(await failurePredicate(), error);
+    }
+
+    /// <summary>
+    /// Returns a Result that is failed when the ValueTask predicate evaluates to true, otherwise successful.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="failurePredicate">Asynchronous predicate that determines whether the Result is failed.</param>
+    /// <param name="value">The value to use when the Result is successful.</param>
+    /// <param name="error">The error message to use when the Result is failed.</param>
+    /// <returns>A ValueTask that contains the resulting Result.</returns>
+    public static async ValueTask<Result<TValue>> FailureIfAsync<TValue>(Func<ValueTask<bool>> failurePredicate, TValue value, string error)
+    {
+        ArgumentNullException.ThrowIfNull(failurePredicate);
+        return await FailureIfAsync(await failurePredicate(), value, error);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FailureIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FailureIfTests.Task.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class FailureIfTestsTask
+{
+    [Fact]
+    public async Task FailureIfAsyncTaskPredicateReturnsFailWhenPredicateReturnsTrue()
+    {
+        var output = await ResultExtensions.FailureIfAsync(() => Task.FromResult(true), "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncTaskPredicateReturnsOkWhenPredicateReturnsFalse()
+    {
+        var output = await ResultExtensions.FailureIfAsync(() => Task.FromResult(false), "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncTaskPredicateWithValueReturnsFailWhenPredicateReturnsTrue()
+    {
+        var output = await ResultExtensions.FailureIfAsync(() => Task.FromResult(true), 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncTaskPredicateWithValueReturnsOkWithValueWhenPredicateReturnsFalse()
+    {
+        var value = new object();
+        var output = await ResultExtensions.FailureIfAsync(() => Task.FromResult(false), value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncTaskPredicateThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.FailureIfAsync((Func<Task<bool>>)null!, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncTaskPredicateWithValueThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.FailureIfAsync((Func<Task<bool>>)null!, 10, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FailureIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FailureIfTests.ValueTask.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class FailureIfTestsValueTask
+{
+    [Fact]
+    public async Task FailureIfAsyncValueTaskPredicateReturnsFailWhenPredicateReturnsTrue()
+    {
+        var output = await ResultExtensions.FailureIfAsync(() => ValueTask.FromResult(true), "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncValueTaskPredicateReturnsOkWhenPredicateReturnsFalse()
+    {
+        var output = await ResultExtensions.FailureIfAsync(() => ValueTask.FromResult(false), "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncValueTaskPredicateWithValueReturnsFailWhenPredicateReturnsTrue()
+    {
+        var output = await ResultExtensions.FailureIfAsync(() => ValueTask.FromResult(true), 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncValueTaskPredicateWithValueReturnsOkWithValueWhenPredicateReturnsFalse()
+    {
+        var value = new object();
+        var output = await ResultExtensions.FailureIfAsync(() => ValueTask.FromResult(false), value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncValueTaskPredicateThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.FailureIfAsync((Func<ValueTask<bool>>)null!, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncValueTaskPredicateWithValueThrowsWhenPredicateIsNull()
+    {
+        var action = async () => await ResultExtensions.FailureIfAsync((Func<ValueTask<bool>>)null!, 10, "error");
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FailureIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FailureIfTests.cs
@@ -1,0 +1,128 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class FailureIfTests
+{
+    [Fact]
+    public void FailureIfBoolReturnsFailWhenConditionTrue()
+    {
+        var output = ResultExtensions.FailureIf(true, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void FailureIfBoolReturnsOkWhenConditionFalse()
+    {
+        var output = ResultExtensions.FailureIf(false, "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FailureIfBoolWithValueReturnsFailWhenConditionTrue()
+    {
+        var output = ResultExtensions.FailureIf(true, 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void FailureIfBoolWithValueReturnsOkWithValueWhenConditionFalse()
+    {
+        var value = new object();
+        var output = ResultExtensions.FailureIf(false, value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public void FailureIfPredicateReturnsFailWhenPredicateReturnsTrue()
+    {
+        var output = ResultExtensions.FailureIf(() => true, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void FailureIfPredicateReturnsOkWhenPredicateReturnsFalse()
+    {
+        var output = ResultExtensions.FailureIf(() => false, "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FailureIfPredicateWithValueReturnsFailWhenPredicateReturnsTrue()
+    {
+        var output = ResultExtensions.FailureIf(() => true, 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public void FailureIfPredicateWithValueReturnsOkWithValueWhenPredicateReturnsFalse()
+    {
+        var value = new object();
+        var output = ResultExtensions.FailureIf(() => false, value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+
+    [Fact]
+    public void FailureIfPredicateThrowsWhenPredicateIsNull()
+    {
+        var action = () => ResultExtensions.FailureIf((Func<bool>)null!, "error");
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void FailureIfPredicateWithValueThrowsWhenPredicateIsNull()
+    {
+        var action = () => ResultExtensions.FailureIf((Func<bool>)null!, 10, "error");
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncBoolReturnsFailWhenConditionTrue()
+    {
+        var output = await ResultExtensions.FailureIfAsync(true, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncBoolReturnsOkWhenConditionFalse()
+    {
+        var output = await ResultExtensions.FailureIfAsync(false, "error");
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncBoolWithValueReturnsFailWhenConditionTrue()
+    {
+        var output = await ResultExtensions.FailureIfAsync(true, 10, "error");
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(x => x.Message == "error");
+    }
+
+    [Fact]
+    public async Task FailureIfAsyncBoolWithValueReturnsOkWithValueWhenConditionFalse()
+    {
+        var value = new object();
+        var output = await ResultExtensions.FailureIfAsync(false, value, "error");
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(value);
+    }
+}


### PR DESCRIPTION
## What
- Added `FailureIf` sync overloads aligned with CSharpFunctionalExtensions-style naming.
- Added `FailureIfAsync` overloads for bool, `Task` predicate, and `ValueTask` predicate variants (with and without value).
- Added unit tests for sync/Task/ValueTask behavior and null-guard scenarios.
- Updated README with `FailureIf` usage examples.

## Why
- Implements issue #51 to provide `FailureIf` API symmetry with existing `SuccessIf` support and align the extensions library with CSharpFunctionalExtensions conventions.

## How to test
- `dotnet test`

## Risks
- Additive API changes only; no breaking behavior expected.
- A prerequisite script referenced by prompt (`.specify/scripts/powershell/check-prerequisites.ps1`) is not present in this repository.

Closes #51