### PR TITLE
feat(result): add FirstFailureOrSuccess methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,23 @@ var asyncOutput = await ResultExtensions.FailureIfAsync(
     "Amount must be positive");
 ```
 
+### FirstFailureOrSuccess
+
+`FirstFailureOrSuccess` provides CSharpFunctionalExtensions-style short-circuit failure selection.
+It returns the first failed `Result` from the provided sequence or `Result.Ok()` when all results are successful.
+This differs from FluentResults `Merge`, which aggregates reasons from all results.
+
+```csharp
+var output = ResultExtensions.FirstFailureOrSuccess(
+    Result.Ok(),
+    Result.Fail("Validation failed"),
+    Result.Fail("Will not be returned"));
+
+var asyncOutput = await ResultExtensions.FirstFailureOrSuccessAsync(
+    Task.FromResult(Result.Ok()),
+    Task.FromResult(Result.Fail("Validation failed")));
+```
+
 ### EnsureNot
 
 `EnsureNot` provides CSharpFunctionalExtensions-style inverted predicate checks for `Result<TValue>`.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FirstFailureOrSuccess.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FirstFailureOrSuccess.Task.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the first failed result from the supplied asynchronous results.
+    /// If there is no failed result, returns a successful result.
+    /// </summary>
+    /// <param name="results">The task-based results to inspect.</param>
+    /// <returns>The first failed result, or a successful result when all inputs are successful.</returns>
+    public static async Task<Result> FirstFailureOrSuccessAsync(params Task<Result>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        foreach (var resultTask in results)
+        {
+            ArgumentNullException.ThrowIfNull(resultTask);
+
+            var result = await resultTask.ConfigureAwait(false);
+            if (result.IsFailed)
+            {
+                return result;
+            }
+        }
+
+        return Result.Ok();
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FirstFailureOrSuccess.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FirstFailureOrSuccess.ValueTask.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the first failed result from the supplied asynchronous value-task results.
+    /// If there is no failed result, returns a successful result.
+    /// </summary>
+    /// <param name="results">The value-task-based results to inspect.</param>
+    /// <returns>The first failed result, or a successful result when all inputs are successful.</returns>
+    public static async ValueTask<Result> FirstFailureOrSuccessAsync(params ValueTask<Result>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        foreach (var resultTask in results)
+        {
+            var result = await resultTask.ConfigureAwait(false);
+            if (result.IsFailed)
+            {
+                return result;
+            }
+        }
+
+        return Result.Ok();
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FirstFailureOrSuccess.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/FirstFailureOrSuccess.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the first failed result from the supplied results.
+    /// If there is no failed result, returns a successful result.
+    /// </summary>
+    /// <param name="results">The results to inspect.</param>
+    /// <returns>The first failed result, or a successful result when all inputs are successful.</returns>
+    public static Result FirstFailureOrSuccess(params Result[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        foreach (var result in results)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+
+            if (result.IsFailed)
+            {
+                return result;
+            }
+        }
+
+        return Result.Ok();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FirstFailureOrSuccessTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FirstFailureOrSuccessTests.Task.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class FirstFailureOrSuccessTestsTask
+{
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncTaskReturnsFirstFailedResult()
+    {
+        var firstFailure = Result.Fail("Failure 1");
+        var secondFailure = Result.Fail("Failure 2");
+
+        var output = await ResultExtensions.FirstFailureOrSuccessAsync(
+            Task.FromResult(Result.Ok()),
+            Task.FromResult(firstFailure),
+            Task.FromResult(secondFailure));
+
+        output.IsFailed.Should().BeTrue();
+        output.Should().BeSameAs(firstFailure);
+        output.Errors.Should().ContainSingle(error => error.Message == "Failure 1");
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncTaskReturnsSuccessWhenAllAreSuccessful()
+    {
+        var output = await ResultExtensions.FirstFailureOrSuccessAsync(
+            Task.FromResult(Result.Ok()),
+            Task.FromResult(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.FirstFailureOrSuccessAsync(Array.Empty<Task<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.FirstFailureOrSuccessAsync((Task<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncTaskThrowsWhenResultTaskItemIsNull()
+    {
+        Task<Result>[] inputs = [Task.FromResult(Result.Ok()), null!, Task.FromResult(Result.Fail("Failure"))];
+
+        var action = async () => await ResultExtensions.FirstFailureOrSuccessAsync(inputs);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FirstFailureOrSuccessTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FirstFailureOrSuccessTests.ValueTask.cs
@@ -1,0 +1,46 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class FirstFailureOrSuccessTestsValueTask
+{
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncValueTaskReturnsFirstFailedResult()
+    {
+        var firstFailure = Result.Fail("Failure 1");
+        var secondFailure = Result.Fail("Failure 2");
+
+        var output = await ResultExtensions.FirstFailureOrSuccessAsync(
+            new ValueTask<Result>(Result.Ok()),
+            new ValueTask<Result>(firstFailure),
+            new ValueTask<Result>(secondFailure));
+
+        output.IsFailed.Should().BeTrue();
+        output.Should().BeSameAs(firstFailure);
+        output.Errors.Should().ContainSingle(error => error.Message == "Failure 1");
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncValueTaskReturnsSuccessWhenAllAreSuccessful()
+    {
+        var output = await ResultExtensions.FirstFailureOrSuccessAsync(
+            new ValueTask<Result>(Result.Ok()),
+            new ValueTask<Result>(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncValueTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.FirstFailureOrSuccessAsync(Array.Empty<ValueTask<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FirstFailureOrSuccessAsyncValueTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.FirstFailureOrSuccessAsync((ValueTask<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FirstFailureOrSuccessTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/FirstFailureOrSuccessTests.cs
@@ -1,0 +1,52 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class FirstFailureOrSuccessTests
+{
+    [Fact]
+    public void FirstFailureOrSuccessReturnsFirstFailedResult()
+    {
+        var firstSuccess = Result.Ok();
+        var firstFailure = Result.Fail("Failure 1");
+        var secondFailure = Result.Fail("Failure 2");
+
+        var output = ResultExtensions.FirstFailureOrSuccess(firstSuccess, firstFailure, secondFailure);
+
+        output.IsFailed.Should().BeTrue();
+        output.Should().BeSameAs(firstFailure);
+        output.Errors.Should().ContainSingle(error => error.Message == "Failure 1");
+    }
+
+    [Fact]
+    public void FirstFailureOrSuccessReturnsSuccessWhenAllAreSuccessful()
+    {
+        var output = ResultExtensions.FirstFailureOrSuccess(Result.Ok(), Result.Ok(), Result.Ok());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FirstFailureOrSuccessReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = ResultExtensions.FirstFailureOrSuccess();
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FirstFailureOrSuccessThrowsWhenResultsArrayIsNull()
+    {
+        var action = () => ResultExtensions.FirstFailureOrSuccess(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void FirstFailureOrSuccessThrowsWhenResultItemIsNull()
+    {
+        Result?[] inputs = [Result.Ok(), null, Result.Fail("Failure")];
+
+        var action = () => ResultExtensions.FirstFailureOrSuccess(inputs!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Add `FirstFailureOrSuccess` support aligned with CSharpFunctionalExtensions.

## Why
Issue #52 requests this behavior. FluentResults `Merge` aggregates errors, while this API must return only the first failure in order.

## How to test
1. Run: `dotnet test NKZSoft.FluentResults.Extensions.Functional.sln -c Debug`
2. Verify new tests:
- `FirstFailureOrSuccessTests`
- `FirstFailureOrSuccessTestsTask`
- `FirstFailureOrSuccessTestsValueTask`

## Risks
- Minimal behavioral risk: adds new methods only.
- Null-guard behavior is explicit for arrays and task entries.

Closes #52