### PR TITLE
feat(result): add Compensate extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ var asyncOutput = await GetCustomerResultAsync()
     .OnSuccessTryAsync(async c => await SendNotificationAsync(c));
 ```
 
+### Compensate
+
+Recovers from failure by executing a fallback function only when the source result is failed.
+For successful source results, the original result instance is returned unchanged.
+
+```csharp
+var recovered = Result.Fail("Validation failed")
+    .Compensate(() => Result.Ok());
+
+var recoveredWithErrors = Result.Fail<int>("Validation failed")
+    .Compensate(errors => Result.Ok(42));
+
+var asyncRecovered = await GetCustomerResultAsync()
+    .CompensateAsync(errors => RecoverCustomerAsync(errors));
+```
+
 ### Of
 
 Creates successful results from values and value-producing delegates.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.Task.Left.cs
@@ -1,0 +1,68 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result> CompensateAsync(this Task<Result> resultTask, Func<Result> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result> CompensateAsync(
+        this Task<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Result> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result<TValue>> CompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<Result<TValue>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result<TValue>> CompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Result<TValue>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.Task.Right.cs
@@ -1,0 +1,60 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static Task<Result> CompensateAsync(this Result result, Func<Task<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate() : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static Task<Result> CompensateAsync(
+        this Result result,
+        Func<IReadOnlyCollection<IError>, Task<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate(result.Errors) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static Task<Result<TValue>> CompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<Task<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate() : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static Task<Result<TValue>> CompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<IReadOnlyCollection<IError>, Task<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate(result.Errors) : Task.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.Task.cs
@@ -1,0 +1,134 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result> CompensateAsync(this Task<Result> resultTask, Func<Task<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result> CompensateAsync(
+        this Task<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result<TValue>> CompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<Task<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result<TValue>> CompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result> CompensateAsync(
+        this Task<Result> resultTask,
+        Func<ValueTask<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result> CompensateAsync(
+        this Task<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result<TValue>> CompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<ValueTask<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A task containing the original successful result or the fallback result.</returns>
+    public static async Task<Result<TValue>> CompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.ValueTask.Left.cs
@@ -1,0 +1,68 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful value-task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result> CompensateAsync(this ValueTask<Result> resultTask, Func<Result> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result> CompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Result> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<Result<TValue>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Result<TValue>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.Compensate(compensate);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.ValueTask.Right.cs
@@ -1,0 +1,60 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static ValueTask<Result> CompensateAsync(this Result result, Func<ValueTask<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate() : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static ValueTask<Result> CompensateAsync(
+        this Result result,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate(result.Errors) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<ValueTask<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate() : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate(result.Errors) : ValueTask.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.ValueTask.cs
@@ -1,0 +1,136 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result> CompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<ValueTask<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result> CompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<ValueTask<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result> CompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<Task<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result> CompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<Task<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the original successful value-task result, or asynchronously executes the fallback when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="compensate">Asynchronous fallback factory executed only when the source is failed.</param>
+    /// <returns>A ValueTask containing the original successful result or the fallback result.</returns>
+    public static async ValueTask<Result<TValue>> CompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result<TValue>>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.CompensateAsync(compensate).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Compensate.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Returns the original successful result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result Compensate(this Result result, Func<Result> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate() : result;
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result Compensate(this Result result, Func<IReadOnlyCollection<IError>, Result> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate(result.Errors) : result;
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result<TValue> Compensate<TValue>(this Result<TValue> result, Func<Result<TValue>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate() : result;
+    }
+
+    /// <summary>
+    /// Returns the original successful result, or the fallback result when the source is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result<TValue> Compensate<TValue>(
+        this Result<TValue> result,
+        Func<IReadOnlyCollection<IError>, Result<TValue>> compensate)
+    {
+        ArgumentNullException.ThrowIfNull(compensate);
+        return result.IsFailed ? compensate(result.Errors) : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Base.cs
@@ -1,0 +1,98 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class CompensateTestsBase : TestBase
+{
+    protected IReadOnlyCollection<IError>? ReceivedErrors { get; private set; }
+
+    protected Result OkCompensate()
+    {
+        FuncExecuted = true;
+        return Result.Ok();
+    }
+
+    protected Result<TValue> OkCompensateT()
+    {
+        FuncExecuted = true;
+        return Result.Ok(TValue.Value);
+    }
+
+    protected Result FailCompensate()
+    {
+        FuncExecuted = true;
+        return Result.Fail(ErrorMessage);
+    }
+
+    protected Result<TValue> FailCompensateT()
+    {
+        FuncExecuted = true;
+        return Result.Fail<TValue>(ErrorMessage);
+    }
+
+    protected Result OkCompensate(IReadOnlyCollection<IError> errors)
+    {
+        FuncExecuted = true;
+        ReceivedErrors = errors;
+        return Result.Ok();
+    }
+
+    protected Result<TValue> OkCompensateT(IReadOnlyCollection<IError> errors)
+    {
+        FuncExecuted = true;
+        ReceivedErrors = errors;
+        return Result.Ok(TValue.Value);
+    }
+
+    protected Task<Result> TaskOkCompensateAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok());
+    }
+
+    protected Task<Result<TValue>> TaskOkCompensateTAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok(TValue.Value));
+    }
+
+    protected Task<Result> TaskOkCompensateAsync(IReadOnlyCollection<IError> errors)
+    {
+        FuncExecuted = true;
+        ReceivedErrors = errors;
+        return Task.FromResult(Result.Ok());
+    }
+
+    protected Task<Result<TValue>> TaskOkCompensateTAsync(IReadOnlyCollection<IError> errors)
+    {
+        FuncExecuted = true;
+        ReceivedErrors = errors;
+        return Task.FromResult(Result.Ok(TValue.Value));
+    }
+
+    protected ValueTask<Result> ValueTaskOkCompensateAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok());
+    }
+
+    protected ValueTask<Result<TValue>> ValueTaskOkCompensateTAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok(TValue.Value));
+    }
+
+    protected ValueTask<Result> ValueTaskOkCompensateAsync(IReadOnlyCollection<IError> errors)
+    {
+        FuncExecuted = true;
+        ReceivedErrors = errors;
+        return ValueTask.FromResult(Result.Ok());
+    }
+
+    protected ValueTask<Result<TValue>> ValueTaskOkCompensateTAsync(IReadOnlyCollection<IError> errors)
+    {
+        FuncExecuted = true;
+        ReceivedErrors = errors;
+        return ValueTask.FromResult(Result.Ok(TValue.Value));
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Task.Left.cs
@@ -1,0 +1,53 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTestsTaskLeft : CompensateTestsBase
+{
+    [Fact]
+    public async Task CompensateAsyncReturnsOriginalTaskResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await Task.FromResult(result).CompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncExecutesFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail(ErrorMessage)).CompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await Task.FromResult(result).CompensateAsync(errors => OkCompensate(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTReturnsOriginalTaskResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).CompensateAsync(() => OkCompensateT());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncThrowsWhenFallbackIsNull()
+    {
+        var action = async () => await Task.FromResult(Result.Ok()).CompensateAsync((Func<Result>)null!);
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Task.Right.cs
@@ -1,0 +1,53 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTestsTaskRight : CompensateTestsBase
+{
+    [Fact]
+    public async Task CompensateAsyncReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await result.CompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncExecutesTaskFallbackWhenSourceIsFailed()
+    {
+        var output = await Result.Fail(ErrorMessage).CompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await result.CompensateAsync(errors => TaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.CompensateAsync(() => TaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncThrowsWhenFallbackIsNull()
+    {
+        var action = async () => await Result.Ok().CompensateAsync((Func<Task<Result>>)null!);
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.Task.cs
@@ -1,0 +1,68 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTestsTask : CompensateTestsBase
+{
+    [Fact]
+    public async Task CompensateAsyncExecutesTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail(ErrorMessage))
+            .CompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncExecutesValueTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail(ErrorMessage))
+            .CompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsTaskFallbackPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await Task.FromResult(result).CompensateAsync(errors => TaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsValueTaskFallbackPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await Task.FromResult(result).CompensateAsync(errors => ValueTaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTExecutesTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail<TValue>(ErrorMessage))
+            .CompensateAsync(() => TaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTExecutesValueTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail<TValue>(ErrorMessage))
+            .CompensateAsync(() => ValueTaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.ValueTask.Left.cs
@@ -1,0 +1,53 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTestsValueTaskLeft : CompensateTestsBase
+{
+    [Fact]
+    public async Task CompensateAsyncReturnsOriginalValueTaskResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await new ValueTask<Result>(result).CompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncExecutesFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result>(Result.Fail(ErrorMessage)).CompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await new ValueTask<Result>(result).CompensateAsync(errors => OkCompensate(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTReturnsOriginalValueTaskResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).CompensateAsync(() => OkCompensateT());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncThrowsWhenFallbackIsNull()
+    {
+        var action = async () => await new ValueTask<Result>(Result.Ok()).CompensateAsync((Func<Result>)null!);
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.ValueTask.Right.cs
@@ -1,0 +1,53 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTestsValueTaskRight : CompensateTestsBase
+{
+    [Fact]
+    public async Task CompensateAsyncReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await result.CompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncExecutesValueTaskFallbackWhenSourceIsFailed()
+    {
+        var output = await Result.Fail(ErrorMessage).CompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await result.CompensateAsync(errors => ValueTaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.CompensateAsync(() => ValueTaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncThrowsWhenFallbackIsNull()
+    {
+        var action = async () => await Result.Ok().CompensateAsync((Func<ValueTask<Result>>)null!);
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.ValueTask.cs
@@ -1,0 +1,68 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTestsValueTask : CompensateTestsBase
+{
+    [Fact]
+    public async Task CompensateAsyncExecutesValueTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result>(Result.Fail(ErrorMessage))
+            .CompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncExecutesTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result>(Result.Fail(ErrorMessage))
+            .CompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsValueTaskFallbackPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await new ValueTask<Result>(result).CompensateAsync(errors => ValueTaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncWithErrorsTaskFallbackPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await new ValueTask<Result>(result).CompensateAsync(errors => TaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTExecutesValueTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Fail<TValue>(ErrorMessage))
+            .CompensateAsync(() => ValueTaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public async Task CompensateAsyncTExecutesTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Fail<TValue>(ErrorMessage))
+            .CompensateAsync(() => TaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompensateTests.cs
@@ -1,0 +1,100 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompensateTests : CompensateTestsBase
+{
+    [Fact]
+    public void CompensateReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = result.Compensate(() => OkCompensate());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public void CompensateExecutesFallbackWhenSourceIsFailed()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        var output = result.Compensate(() => OkCompensate());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CompensateWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = result.Compensate(errors => OkCompensate(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public void CompensateTReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.Compensate(() => OkCompensateT());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public void CompensateTExecutesFallbackWhenSourceIsFailed()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = result.Compensate(() => OkCompensateT());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public void CompensateTWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        _ = result.Compensate(errors => OkCompensateT(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public void CompensateThrowsWhenFallbackIsNull()
+    {
+        var action = () => Result.Ok().Compensate((Func<Result>)null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CompensateWithErrorsThrowsWhenFallbackIsNull()
+    {
+        var action = () => Result.Ok().Compensate((Func<IReadOnlyCollection<IError>, Result>)null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CompensateTThrowsWhenFallbackIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).Compensate((Func<Result<TValue>>)null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CompensateTWithErrorsThrowsWhenFallbackIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).Compensate((Func<IReadOnlyCollection<IError>, Result<TValue>>)null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Implements issue #46 by adding CSharpFunctionalExtensions-style Compensate support for FluentResults extension methods.

## Why
The project tracks functional parity goals with CSharpFunctionalExtensions and needed a recovery API that executes fallback logic only on failure.

## How to test
- Run: dotnet test NKZSoft.FluentResults.Extensions.Functional.sln
- Verify new Compensate tests pass across 
et8.0, 
et9.0, 
et10.0.

## Risks
- API surface growth due full sync/Task/ValueTask overload family.
- Overload ambiguity risk mitigated by explicit delegate shapes and dedicated tests.

Closes #46