### PR TITLE
feat(result): add OnFailureCompensate extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,22 @@ var asyncRecovered = await GetCustomerResultAsync()
     .CompensateAsync(errors => RecoverCustomerAsync(errors));
 ```
 
+### OnFailureCompensate
+
+`OnFailureCompensate` is a CSharpFunctionalExtensions-style alias for `Compensate`.
+It executes fallback logic only when the source result is failed.
+
+```csharp
+var recovered = Result.Fail("Validation failed")
+    .OnFailureCompensate(() => Result.Ok());
+
+var recoveredWithValue = Result.Fail<int>("Validation failed")
+    .OnFailureCompensate(errors => Result.Ok(42));
+
+var asyncRecovered = await GetCustomerResultAsync()
+    .OnFailureCompensateAsync(errors => RecoverCustomerAsync(errors));
+```
+
 ### Of
 
 Creates successful results from values and value-producing delegates.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.Task.Left.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(this Task<Result> resultTask, Func<Result> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(
+        this Task<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Result> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<Result<TValue>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Result<TValue>> compensate)
+        => resultTask.CompensateAsync(compensate);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.Task.Right.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(this Result result, Func<Task<Result>> compensate)
+        => result.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(
+        this Result result,
+        Func<IReadOnlyCollection<IError>, Task<Result>> compensate)
+        => result.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<Task<Result<TValue>>> compensate)
+        => result.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<IReadOnlyCollection<IError>, Task<Result<TValue>>> compensate)
+        => result.CompensateAsync(compensate);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.Task.cs
@@ -1,0 +1,64 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(this Task<Result> resultTask, Func<Task<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(
+        this Task<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<Task<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(this Task<Result> resultTask, Func<ValueTask<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result> OnFailureCompensateAsync(
+        this Task<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<ValueTask<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static Task<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.ValueTask.Left.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(this ValueTask<Result> resultTask, Func<Result> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Result> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<Result<TValue>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Result<TValue>> compensate)
+        => resultTask.CompensateAsync(compensate);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.ValueTask.Right.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(this Result result, Func<ValueTask<Result>> compensate)
+        => result.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(
+        this Result result,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result>> compensate)
+        => result.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<ValueTask<Result<TValue>>> compensate)
+        => result.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this Result<TValue> result,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result<TValue>>> compensate)
+        => result.CompensateAsync(compensate);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.ValueTask.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<ValueTask<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<ValueTask<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, ValueTask<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(this ValueTask<Result> resultTask, Func<Task<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result> OnFailureCompensateAsync(
+        this ValueTask<Result> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<Task<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+
+    /// <summary>
+    /// Executes asynchronous fallback logic only when the awaited source result is failed; otherwise returns the source result.
+    /// </summary>
+    public static ValueTask<Result<TValue>> OnFailureCompensateAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IReadOnlyCollection<IError>, Task<Result<TValue>>> compensate)
+        => resultTask.CompensateAsync(compensate);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/OnFailureCompensate.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result OnFailureCompensate(this Result result, Func<Result> compensate)
+        => result.Compensate(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result OnFailureCompensate(this Result result, Func<IReadOnlyCollection<IError>, Result> compensate)
+        => result.Compensate(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result<TValue> OnFailureCompensate<TValue>(this Result<TValue> result, Func<Result<TValue>> compensate)
+        => result.Compensate(compensate);
+
+    /// <summary>
+    /// Executes fallback logic only when the source result is failed; otherwise returns the source result.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="compensate">Fallback factory executed only when the source is failed.</param>
+    /// <returns>The original successful result or the fallback result.</returns>
+    public static Result<TValue> OnFailureCompensate<TValue>(
+        this Result<TValue> result,
+        Func<IReadOnlyCollection<IError>, Result<TValue>> compensate)
+        => result.Compensate(compensate);
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.Task.Left.cs
@@ -1,0 +1,35 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTestsTaskLeft : CompensateTestsBase
+{
+    [Fact]
+    public async Task OnFailureCompensateAsyncReturnsOriginalTaskResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await Task.FromResult(result).OnFailureCompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail(ErrorMessage)).OnFailureCompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await Task.FromResult(result).OnFailureCompensateAsync(errors => OkCompensate(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.Task.Right.cs
@@ -1,0 +1,35 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTestsTaskRight : CompensateTestsBase
+{
+    [Fact]
+    public async Task OnFailureCompensateAsyncReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await result.OnFailureCompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesTaskFallbackWhenSourceIsFailed()
+    {
+        var output = await Result.Fail(ErrorMessage).OnFailureCompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await result.OnFailureCompensateAsync(errors => TaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.Task.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTestsTask : CompensateTestsBase
+{
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail(ErrorMessage))
+            .OnFailureCompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesValueTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail(ErrorMessage))
+            .OnFailureCompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncTExecutesTaskFallbackWhenTaskSourceIsFailed()
+    {
+        var output = await Task.FromResult(Result.Fail<TValue>(ErrorMessage))
+            .OnFailureCompensateAsync(() => TaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.ValueTask.Left.cs
@@ -1,0 +1,35 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTestsValueTaskLeft : CompensateTestsBase
+{
+    [Fact]
+    public async Task OnFailureCompensateAsyncReturnsOriginalValueTaskResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await new ValueTask<Result>(result).OnFailureCompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result>(Result.Fail(ErrorMessage)).OnFailureCompensateAsync(() => OkCompensate());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await new ValueTask<Result>(result).OnFailureCompensateAsync(errors => OkCompensate(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.ValueTask.Right.cs
@@ -1,0 +1,35 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTestsValueTaskRight : CompensateTestsBase
+{
+    [Fact]
+    public async Task OnFailureCompensateAsyncReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await result.OnFailureCompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesValueTaskFallbackWhenSourceIsFailed()
+    {
+        var output = await Result.Fail(ErrorMessage).OnFailureCompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = await result.OnFailureCompensateAsync(errors => ValueTaskOkCompensateAsync(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.ValueTask.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTestsValueTask : CompensateTestsBase
+{
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesValueTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result>(Result.Fail(ErrorMessage))
+            .OnFailureCompensateAsync(() => ValueTaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncExecutesTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result>(Result.Fail(ErrorMessage))
+            .OnFailureCompensateAsync(() => TaskOkCompensateAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task OnFailureCompensateAsyncTExecutesValueTaskFallbackWhenValueTaskSourceIsFailed()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Fail<TValue>(ErrorMessage))
+            .OnFailureCompensateAsync(() => ValueTaskOkCompensateTAsync());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/OnFailureCompensateTests.cs
@@ -1,0 +1,67 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class OnFailureCompensateTests : CompensateTestsBase
+{
+    [Fact]
+    public void OnFailureCompensateReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = result.OnFailureCompensate(() => OkCompensate());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public void OnFailureCompensateExecutesFallbackWhenSourceIsFailed()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        var output = result.OnFailureCompensate(() => OkCompensate());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OnFailureCompensateWithErrorsPassesSourceErrors()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        _ = result.OnFailureCompensate(errors => OkCompensate(errors));
+
+        FuncExecuted.Should().BeTrue();
+        ReceivedErrors.Should().BeEquivalentTo(result.Errors);
+    }
+
+    [Fact]
+    public void OnFailureCompensateTReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.OnFailureCompensate(() => OkCompensateT());
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Fact]
+    public void OnFailureCompensateTExecutesFallbackWhenSourceIsFailed()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = result.OnFailureCompensate(() => OkCompensateT());
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValue.Value);
+    }
+
+    [Fact]
+    public void OnFailureCompensateThrowsWhenFallbackIsNull()
+    {
+        var action = () => Result.Ok().OnFailureCompensate((Func<Result>)null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Implements issue #59 by adding CSharpFunctionalExtensions-style OnFailureCompensate APIs for FluentResults extensions.

## Why
OnFailureCompensate is part of the parity roadmap and provides explicit failure-recovery naming for users migrating from CSharpFunctionalExtensions.

## How to test
- Run: dotnet test NKZSoft.FluentResults.Extensions.Functional.sln
- Verify OnFailureCompensate tests pass across 
et8.0, 
et9.0, 
et10.0.

## Risks
- Added overload surface can increase discoverability noise; behavior is intentionally delegated to existing Compensate semantics to minimize divergence.

Closes #59