### PR TITLE
feat(result): add GetValueOrDefault extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,26 @@ public Task<Result<int>> GetNumberAsync()
 var output2 = await GetNumberAsync().SelectAsync(v => v + 1);
 ```
 
+### GetValueOrDefault
+
+Returns the successful value from `Result<TValue>` or a fallback when the result is failed.
+Includes selector overloads and async variants for `Task<Result<TValue>>` / `ValueTask<Result<TValue>>`.
+
+```csharp
+Result<int> amountResult = Result.Ok(10);
+int amount = amountResult.GetValueOrDefault(0);
+
+Result<int> failedAmountResult = Result.Fail<int>("Amount is missing");
+int amountWithFallback = failedAmountResult.GetValueOrDefault(() => 0);
+
+string text = failedAmountResult.GetValueOrDefault(
+    value => value.ToString(),
+    () => "N/A");
+
+Task<Result<int>> amountTask = GetAmountAsync();
+int fromTask = await amountTask.GetValueOrDefaultAsync(0);
+```
+
 ### SelectMany
 
 LINQ-friendly alias composition for `Bind` + `Map`.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.Task.Left.cs
@@ -1,0 +1,57 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result from a task; otherwise returns the provided default value.
+    /// </summary>
+    public static async Task<TValue> GetValueOrDefaultAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        TValue defaultValue = default!)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(defaultValue);
+    }
+
+    /// <summary>
+    /// Gets the value of a successful result from a task; otherwise returns a fallback value produced by a function.
+    /// </summary>
+    public static async Task<TValue> GetValueOrDefaultAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(defaultValue);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a task; otherwise returns the provided default value.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(selector, defaultValue);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a task; otherwise returns a fallback value produced by a function.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> selector,
+        Func<TValueOut> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(selector, defaultValue);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.Task.Right.cs
@@ -1,0 +1,43 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async Task<TValue> GetValueOrDefaultAsync<TValue>(
+        this Result<TValue> result,
+        Func<Task<TValue>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return result.IsSuccess ? result.Value : await defaultValue().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result; otherwise returns the provided default value.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Task<TValueOut>> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return result.IsSuccess ? await selector(result.Value).ConfigureAwait(false) : defaultValue;
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Task<TValueOut>> selector,
+        Func<Task<TValueOut>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        return result.IsSuccess
+            ? await selector(result.Value).ConfigureAwait(false)
+            : await defaultValue().ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.Task.cs
@@ -1,0 +1,88 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result from a task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async Task<TValue> GetValueOrDefaultAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<Task<TValue>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets the value of a successful result from a task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async Task<TValue> GetValueOrDefaultAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<ValueTask<TValue>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a task; otherwise returns the provided default value.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a task; otherwise returns the provided default value.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> selector,
+        Func<Task<TValueOut>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async Task<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> selector,
+        Func<ValueTask<TValueOut>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.ValueTask.Left.cs
@@ -1,0 +1,57 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result from a value task; otherwise returns the provided default value.
+    /// </summary>
+    public static async ValueTask<TValue> GetValueOrDefaultAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        TValue defaultValue = default!)
+    {
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(defaultValue);
+    }
+
+    /// <summary>
+    /// Gets the value of a successful result from a value task; otherwise returns a fallback value produced by a function.
+    /// </summary>
+    public static async ValueTask<TValue> GetValueOrDefaultAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(defaultValue);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a value task; otherwise returns the provided default value.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(selector, defaultValue);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a value task; otherwise returns a fallback value produced by a function.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> selector,
+        Func<TValueOut> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.GetValueOrDefault(selector, defaultValue);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.ValueTask.Right.cs
@@ -1,0 +1,43 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async ValueTask<TValue> GetValueOrDefaultAsync<TValue>(
+        this Result<TValue> result,
+        Func<ValueTask<TValue>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return result.IsSuccess ? result.Value : await defaultValue().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result; otherwise returns the provided default value.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, ValueTask<TValueOut>> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return result.IsSuccess ? await selector(result.Value).ConfigureAwait(false) : defaultValue;
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, ValueTask<TValueOut>> selector,
+        Func<ValueTask<TValueOut>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        return result.IsSuccess
+            ? await selector(result.Value).ConfigureAwait(false)
+            : await defaultValue().ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.ValueTask.cs
@@ -1,0 +1,88 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result from a value task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async ValueTask<TValue> GetValueOrDefaultAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<ValueTask<TValue>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Gets the value of a successful result from a value task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async ValueTask<TValue> GetValueOrDefaultAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<Task<TValue>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a value task; otherwise returns the provided default value.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a value task; otherwise returns the provided default value.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a value task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> selector,
+        Func<ValueTask<TValueOut>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result from a value task; otherwise returns a fallback value produced by an asynchronous function.
+    /// </summary>
+    public static async ValueTask<TValueOut> GetValueOrDefaultAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> selector,
+        Func<Task<TValueOut>> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.GetValueOrDefaultAsync(selector, defaultValue).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/GetValueOrDefault.cs
@@ -1,0 +1,64 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Gets the value of a successful result; otherwise returns the provided default value.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="defaultValue">The fallback value for failed results.</param>
+    /// <returns>The successful value or <paramref name="defaultValue"/> when failed.</returns>
+    public static TValue GetValueOrDefault<TValue>(this Result<TValue> result, TValue defaultValue = default!)
+        => result.IsSuccess ? result.Value : defaultValue;
+
+    /// <summary>
+    /// Gets the value of a successful result; otherwise returns a fallback value produced by a function.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="defaultValue">The fallback factory for failed results.</param>
+    /// <returns>The successful value or the produced fallback when failed.</returns>
+    public static TValue GetValueOrDefault<TValue>(this Result<TValue> result, Func<TValue> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return result.IsSuccess ? result.Value : defaultValue();
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result; otherwise returns the provided default value.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="selector">The projection to apply on success.</param>
+    /// <param name="defaultValue">The fallback value for failed results.</param>
+    /// <returns>The projected value or <paramref name="defaultValue"/> when failed.</returns>
+    public static TValueOut GetValueOrDefault<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, TValueOut> selector,
+        TValueOut defaultValue = default!)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return result.IsSuccess ? selector(result.Value) : defaultValue;
+    }
+
+    /// <summary>
+    /// Projects the value of a successful result; otherwise returns a fallback value produced by a function.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The projected value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="selector">The projection to apply on success.</param>
+    /// <param name="defaultValue">The fallback factory for failed results.</param>
+    /// <returns>The projected value or the produced fallback when failed.</returns>
+    public static TValueOut GetValueOrDefault<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, TValueOut> selector,
+        Func<TValueOut> defaultValue)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(defaultValue);
+        return result.IsSuccess ? selector(result.Value) : defaultValue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Base.cs
@@ -1,0 +1,68 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class GetValueOrDefaultTestsBase : TestBase
+{
+    protected class TValueSelected
+    {
+        public static readonly TValueSelected Value = new();
+    }
+
+    protected bool DefaultExecuted { get; set; }
+    protected bool SelectorExecuted { get; set; }
+
+    protected TValue DefaultValueFactory()
+    {
+        DefaultExecuted = true;
+        return TValue.Value;
+    }
+
+    protected Task<TValue> DefaultValueFactoryTask()
+    {
+        DefaultExecuted = true;
+        return Task.FromResult(TValue.Value);
+    }
+
+    protected ValueTask<TValue> DefaultValueFactoryValueTask()
+    {
+        DefaultExecuted = true;
+        return ValueTask.FromResult(TValue.Value);
+    }
+
+    protected TValueSelected SelectValue(TValue value)
+    {
+        SelectorExecuted = true;
+        return TValueSelected.Value;
+    }
+
+    protected Task<TValueSelected> SelectValueTask(TValue value)
+    {
+        SelectorExecuted = true;
+        return Task.FromResult(TValueSelected.Value);
+    }
+
+    protected ValueTask<TValueSelected> SelectValueValueTask(TValue value)
+    {
+        SelectorExecuted = true;
+        return ValueTask.FromResult(TValueSelected.Value);
+    }
+
+    protected TValueSelected DefaultSelectedFactory()
+    {
+        DefaultExecuted = true;
+        return TValueSelected.Value;
+    }
+
+    protected Task<TValueSelected> DefaultSelectedFactoryTask()
+    {
+        DefaultExecuted = true;
+        return Task.FromResult(TValueSelected.Value);
+    }
+
+    protected ValueTask<TValueSelected> DefaultSelectedFactoryValueTask()
+    {
+        DefaultExecuted = true;
+        return ValueTask.FromResult(TValueSelected.Value);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Task.Left.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTestsTaskLeft : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public async Task GetValueOrDefaultTaskLeftReturnsResultValueOnSuccess()
+    {
+        var fallback = new TValue();
+        var output = await TaskOkResultTAsync().GetValueOrDefaultAsync(fallback);
+        output.Should().BeSameAs(TValue.Value);
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskLeftReturnsFallbackValueOnFailure()
+    {
+        var fallback = new TValue();
+        var output = await TaskFailResultTAsync().GetValueOrDefaultAsync(fallback);
+        output.Should().BeSameAs(fallback);
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskLeftFactoryRunsOnlyOnFailure()
+    {
+        var successOutput = await TaskOkResultTAsync().GetValueOrDefaultAsync(DefaultValueFactory);
+        successOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = await TaskFailResultTAsync().GetValueOrDefaultAsync(DefaultValueFactory);
+        failedOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskLeftWithSelectorAndFactoryRunsFactoryOnlyOnFailure()
+    {
+        var successOutput = await TaskOkResultTAsync().GetValueOrDefaultAsync(SelectValue, DefaultSelectedFactory);
+        successOutput.Should().BeSameAs(TValueSelected.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = await TaskFailResultTAsync().GetValueOrDefaultAsync(SelectValue, DefaultSelectedFactory);
+        failedOutput.Should().BeSameAs(TValueSelected.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Task.Right.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTestsTaskRight : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public async Task GetValueOrDefaultTaskRightFactoryRunsOnlyOnFailure()
+    {
+        var successOutput = await Result.Ok(TValue.Value).GetValueOrDefaultAsync(DefaultValueFactoryTask);
+        successOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = await Result.Fail<TValue>(ErrorMessage).GetValueOrDefaultAsync(DefaultValueFactoryTask);
+        failedOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskRightWithSelectorUsesDefaultOnFailure()
+    {
+        var output = await Result.Fail<TValue>(ErrorMessage).GetValueOrDefaultAsync(SelectValueTask, TValueSelected.Value);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskRightWithSelectorAndFactoryRunsFactoryOnlyOnFailure()
+    {
+        var successOutput = await Result.Ok(TValue.Value).GetValueOrDefaultAsync(SelectValueTask, DefaultSelectedFactoryTask);
+        successOutput.Should().BeSameAs(TValueSelected.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = await Result.Fail<TValue>(ErrorMessage).GetValueOrDefaultAsync(SelectValueTask, DefaultSelectedFactoryTask);
+        failedOutput.Should().BeSameAs(TValueSelected.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.Task.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTestsTask : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public async Task GetValueOrDefaultTaskUsesAsyncFactoryOnFailure()
+    {
+        var output = await TaskFailResultTAsync().GetValueOrDefaultAsync(DefaultValueFactoryTask);
+        output.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskSupportsValueTaskFactoryOnFailure()
+    {
+        var output = await TaskFailResultTAsync().GetValueOrDefaultAsync(DefaultValueFactoryValueTask);
+        output.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskWithAsyncSelectorUsesSelectorOnSuccess()
+    {
+        var output = await TaskOkResultTAsync().GetValueOrDefaultAsync(SelectValueTask, TValueSelected.Value);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultTaskWithValueTaskSelectorUsesFactoryOnFailure()
+    {
+        var output = await TaskFailResultTAsync().GetValueOrDefaultAsync(SelectValueValueTask, DefaultSelectedFactoryValueTask);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+        DefaultExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.ValueTask.Left.cs
@@ -1,0 +1,32 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTestsValueTaskLeft : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public async Task GetValueOrDefaultValueTaskLeftReturnsResultValueOnSuccess()
+    {
+        var fallback = new TValue();
+        var output = await ValueTaskOkResultTAsync().GetValueOrDefaultAsync(fallback);
+        output.Should().BeSameAs(TValue.Value);
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskLeftFactoryRunsOnlyOnFailure()
+    {
+        var successOutput = await ValueTaskOkResultTAsync().GetValueOrDefaultAsync(DefaultValueFactory);
+        successOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = await ValueTaskFailResultTAsync().GetValueOrDefaultAsync(DefaultValueFactory);
+        failedOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskLeftWithSelectorUsesDefaultOnFailure()
+    {
+        var output = await ValueTaskFailResultTAsync().GetValueOrDefaultAsync(SelectValue, TValueSelected.Value);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.ValueTask.Right.cs
@@ -1,0 +1,33 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTestsValueTaskRight : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public async Task GetValueOrDefaultValueTaskRightFactoryRunsOnlyOnFailure()
+    {
+        var successOutput = await Result.Ok(TValue.Value).GetValueOrDefaultAsync(DefaultValueFactoryValueTask);
+        successOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = await Result.Fail<TValue>(ErrorMessage).GetValueOrDefaultAsync(DefaultValueFactoryValueTask);
+        failedOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskRightWithSelectorUsesDefaultOnFailure()
+    {
+        var output = await Result.Fail<TValue>(ErrorMessage).GetValueOrDefaultAsync(SelectValueValueTask, TValueSelected.Value);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskRightWithSelectorAndFactoryRunsFactoryOnlyOnFailure()
+    {
+        var output = await Result.Fail<TValue>(ErrorMessage).GetValueOrDefaultAsync(SelectValueValueTask, DefaultSelectedFactoryValueTask);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+        DefaultExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.ValueTask.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTestsValueTask : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public async Task GetValueOrDefaultValueTaskUsesAsyncFactoryOnFailure()
+    {
+        var output = await ValueTaskFailResultTAsync().GetValueOrDefaultAsync(DefaultValueFactoryTask);
+        output.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskSupportsValueTaskFactoryOnFailure()
+    {
+        var output = await ValueTaskFailResultTAsync().GetValueOrDefaultAsync(DefaultValueFactoryValueTask);
+        output.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskWithAsyncSelectorUsesSelectorOnSuccess()
+    {
+        var output = await ValueTaskOkResultTAsync().GetValueOrDefaultAsync(SelectValueTask, TValueSelected.Value);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetValueOrDefaultValueTaskWithValueTaskSelectorUsesFactoryOnFailure()
+    {
+        var output = await ValueTaskFailResultTAsync().GetValueOrDefaultAsync(SelectValueValueTask, DefaultSelectedFactoryValueTask);
+        output.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+        DefaultExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/GetValueOrDefaultTests.cs
@@ -1,0 +1,81 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class GetValueOrDefaultTests : GetValueOrDefaultTestsBase
+{
+    [Test]
+    public void GetValueOrDefaultReturnsResultValueOnSuccess()
+    {
+        var fallback = new TValue();
+        var output = Result.Ok(TValue.Value).GetValueOrDefault(fallback);
+        output.Should().BeSameAs(TValue.Value);
+    }
+
+    [Test]
+    public void GetValueOrDefaultReturnsFallbackValueOnFailure()
+    {
+        var fallback = new TValue();
+        var output = Result.Fail<TValue>(ErrorMessage).GetValueOrDefault(fallback);
+        output.Should().BeSameAs(fallback);
+    }
+
+    [Test]
+    public void GetValueOrDefaultFactoryRunsOnlyOnFailure()
+    {
+        var successOutput = Result.Ok(TValue.Value).GetValueOrDefault(DefaultValueFactory);
+        successOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeFalse();
+
+        var failedOutput = Result.Fail<TValue>(ErrorMessage).GetValueOrDefault(DefaultValueFactory);
+        failedOutput.Should().BeSameAs(TValue.Value);
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public void GetValueOrDefaultWithSelectorRunsSelectorOnlyOnSuccess()
+    {
+        var successOutput = Result.Ok(TValue.Value).GetValueOrDefault(SelectValue, TValueSelected.Value);
+        successOutput.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeTrue();
+
+        SelectorExecuted = false;
+        var failedOutput = Result.Fail<TValue>(ErrorMessage).GetValueOrDefault(SelectValue, TValueSelected.Value);
+        failedOutput.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+    }
+
+    [Test]
+    public void GetValueOrDefaultWithSelectorAndFactoryRunsFactoryOnlyOnFailure()
+    {
+        var successOutput = Result.Ok(TValue.Value).GetValueOrDefault(SelectValue, DefaultSelectedFactory);
+        successOutput.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeTrue();
+        DefaultExecuted.Should().BeFalse();
+
+        SelectorExecuted = false;
+        var failedOutput = Result.Fail<TValue>(ErrorMessage).GetValueOrDefault(SelectValue, DefaultSelectedFactory);
+        failedOutput.Should().BeSameAs(TValueSelected.Value);
+        SelectorExecuted.Should().BeFalse();
+        DefaultExecuted.Should().BeTrue();
+    }
+
+    [Test]
+    public void GetValueOrDefaultReturnsNullByDefaultForReferenceTypeOnFailure()
+    {
+        var output = Result.Fail<string?>(ErrorMessage).GetValueOrDefault();
+        output.Should().BeNull();
+    }
+
+    [Test]
+    public void GetValueOrDefaultThrowsWhenFactoryIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).GetValueOrDefault((Func<TValue>)null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void GetValueOrDefaultThrowsWhenSelectorIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).GetValueOrDefault((Func<TValue, TValueSelected>)null!, TValueSelected.Value);
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Add CSharpFunctionalExtensions-style `GetValueOrDefault` support for `Result<TValue>` with sync and async overloads.

## Why
Issue #53 requests API parity-style support for `GetValueOrDefault` behavior and async overloads aligned with project conventions.

## How to test
- Run:
  - `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`
- Expected:
  - All tests pass for `net8.0`, `net9.0`, and `net10.0`.

## Risks
- Added overload surface may introduce method selection ambiguity for some call sites with lambdas; tests cover representative usage patterns.

Closes #53