### PR TITLE
feat(result): add Combine extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,29 @@ var asyncOutput = await ResultExtensions.FailureIfAsync(
 </details>
 
 <details>
+<summary><strong>Combine</strong></summary>
+
+`Combine` provides CSharpFunctionalExtensions-style naming over FluentResults `Merge`.
+It aggregates reasons from all input results and returns success only when all inputs are successful.
+
+```csharp
+var output = ResultExtensions.Combine(
+    Result.Ok(),
+    Result.Fail("Validation failed"),
+    Result.Fail("Another error"));
+
+var outputWithValues = ResultExtensions.Combine(
+    Result.Ok(1),
+    Result.Ok(2));
+
+var asyncOutput = await ResultExtensions.CombineAsync(
+    Task.FromResult(Result.Ok()),
+    Task.FromResult(Result.Fail("Validation failed")));
+```
+
+</details>
+
+<details>
 <summary><strong>FirstFailureOrSuccess</strong></summary>
 
 `FirstFailureOrSuccess` provides CSharpFunctionalExtensions-style short-circuit failure selection.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Combine.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Combine.Task.cs
@@ -1,0 +1,45 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously combines task-based results into a single result.
+    /// </summary>
+    /// <param name="results">Task results to combine.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static async Task<Result> CombineAsync(params Task<Result>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            ArgumentNullException.ThrowIfNull(results[i]);
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return Combine(resolved);
+    }
+
+    /// <summary>
+    /// Asynchronously combines task-based value results into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">Task results to combine.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static async Task<Result<IEnumerable<TValue>>> CombineAsync<TValue>(params Task<Result<TValue>>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result<TValue>[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            ArgumentNullException.ThrowIfNull(results[i]);
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return Combine(resolved);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Combine.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Combine.ValueTask.cs
@@ -1,0 +1,43 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously combines value-task-based results into a single result.
+    /// </summary>
+    /// <param name="results">ValueTask results to combine.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static async ValueTask<Result> CombineAsync(params ValueTask<Result>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return Combine(resolved);
+    }
+
+    /// <summary>
+    /// Asynchronously combines value-task-based value results into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">ValueTask results to combine.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static async ValueTask<Result<IEnumerable<TValue>>> CombineAsync<TValue>(params ValueTask<Result<TValue>>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result<TValue>[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return Combine(resolved);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Combine.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/Combine.cs
@@ -1,0 +1,39 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Combines multiple results into a single result by delegating to FluentResults Merge.
+    /// </summary>
+    /// <param name="results">Results to combine.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static Result Combine(params Result[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        foreach (var result in results)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+        }
+
+        return Result.Merge(results);
+    }
+
+    /// <summary>
+    /// Combines multiple value results into a single value result by delegating to FluentResults Merge.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">Results to combine.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static Result<IEnumerable<TValue>> Combine<TValue>(params Result<TValue>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        foreach (var result in results)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+        }
+
+        return Result.Merge(results);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineTests.Task.cs
@@ -1,0 +1,74 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CombineTestsTask
+{
+    [Test]
+    public async Task CombineAsyncTaskReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            Task.FromResult(Result.Ok()),
+            Task.FromResult(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineAsyncTaskAggregatesErrorsFromAllFailedResults()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            Task.FromResult(Result.Fail("Failure 1")),
+            Task.FromResult(Result.Fail("Failure 2")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public async Task CombineAsyncTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.CombineAsync(Array.Empty<Task<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineAsyncTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.CombineAsync((Task<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CombineAsyncTaskThrowsWhenTaskItemIsNull()
+    {
+        Task<Result>[] inputs = [Task.FromResult(Result.Ok()), null!];
+
+        var action = async () => await ResultExtensions.CombineAsync(inputs);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CombineAsyncTaskTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            Task.FromResult(Result.Ok(1)),
+            Task.FromResult(Result.Ok(2)));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task CombineAsyncTaskTReturnsFailureAndAggregatesErrors()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            Task.FromResult(Result.Ok(1)),
+            Task.FromResult(Result.Fail<int>("Failure")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineTests.ValueTask.cs
@@ -1,0 +1,64 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CombineTestsValueTask
+{
+    [Test]
+    public async Task CombineAsyncValueTaskReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            new ValueTask<Result>(Result.Ok()),
+            new ValueTask<Result>(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineAsyncValueTaskAggregatesErrorsFromAllFailedResults()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            new ValueTask<Result>(Result.Fail("Failure 1")),
+            new ValueTask<Result>(Result.Fail("Failure 2")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public async Task CombineAsyncValueTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.CombineAsync(Array.Empty<ValueTask<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineAsyncValueTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.CombineAsync((ValueTask<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CombineAsyncValueTaskTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            new ValueTask<Result<int>>(Result.Ok(1)),
+            new ValueTask<Result<int>>(Result.Ok(2)));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task CombineAsyncValueTaskTReturnsFailureAndAggregatesErrors()
+    {
+        var output = await ResultExtensions.CombineAsync(
+            new ValueTask<Result<int>>(Result.Ok(1)),
+            new ValueTask<Result<int>>(Result.Fail<int>("Failure")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineTests.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CombineTests
+{
+    [Test]
+    public void CombineReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = ResultExtensions.Combine(Result.Ok(), Result.Ok());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void CombineAggregatesErrorsFromAllFailedResults()
+    {
+        var output = ResultExtensions.Combine(Result.Fail("Failure 1"), Result.Fail("Failure 2"));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public void CombineReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = ResultExtensions.Combine();
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void CombineThrowsWhenResultsArrayIsNull()
+    {
+        var action = () => ResultExtensions.Combine(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CombineThrowsWhenResultItemIsNull()
+    {
+        Result?[] inputs = [Result.Ok(), null, Result.Fail("Failure")];
+
+        var action = () => ResultExtensions.Combine(inputs!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CombineTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = ResultExtensions.Combine(Result.Ok(1), Result.Ok(2));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public void CombineTReturnsFailureAndAggregatesErrors()
+    {
+        var output = ResultExtensions.Combine(Result.Ok(1), Result.Fail<int>("Failure"));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}


### PR DESCRIPTION
## What
Add CSharpFunctionalExtensions-style `Combine` support in this extension library by delegating to FluentResults `Merge` and adding async wrappers.

## Why
Issue #44 requests `Combine` support aligned with CSharpFunctionalExtensions naming and usage patterns.

## How to test
- Run:
  - `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`
- Expected:
  - All tests pass for `net8.0`, `net9.0`, and `net10.0`.

## Risks
- `Combine` is an alias over FluentResults `Merge`, so semantics follow FluentResults reason aggregation.

Closes #44