### PR TITLE
feat: add CombineInOrder extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,30 @@ var asyncOutput = await ResultExtensions.CombineAsync(
 </details>
 
 <details>
+<summary><strong>CombineInOrder</strong></summary>
+
+`CombineInOrder` provides CSharpFunctionalExtensions-style naming for ordered async result combination.
+For synchronous inputs, behavior matches `Combine`.
+For async (`Task`/`ValueTask`) inputs, results are awaited in input order before aggregation.
+
+```csharp
+var output = ResultExtensions.CombineInOrder(
+    Result.Ok(),
+    Result.Fail("Validation failed"),
+    Result.Fail("Another error"));
+
+var outputWithValues = ResultExtensions.CombineInOrder(
+    Result.Ok(1),
+    Result.Ok(2));
+
+var asyncOutput = await ResultExtensions.CombineInOrderAsync(
+    Task.FromResult(Result.Ok()),
+    Task.FromResult(Result.Fail("Validation failed")));
+```
+
+</details>
+
+<details>
 <summary><strong>FirstFailureOrSuccess</strong></summary>
 
 `FirstFailureOrSuccess` provides CSharpFunctionalExtensions-style short-circuit failure selection.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CombineInOrder.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CombineInOrder.Task.cs
@@ -1,0 +1,45 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously combines task-based results in input order into a single result.
+    /// </summary>
+    /// <param name="results">Task results to combine.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static async Task<Result> CombineInOrderAsync(params Task<Result>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            ArgumentNullException.ThrowIfNull(results[i]);
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return CombineInOrder(resolved);
+    }
+
+    /// <summary>
+    /// Asynchronously combines task-based value results in input order into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">Task results to combine.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static async Task<Result<IEnumerable<TValue>>> CombineInOrderAsync<TValue>(params Task<Result<TValue>>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result<TValue>[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            ArgumentNullException.ThrowIfNull(results[i]);
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return CombineInOrder(resolved);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CombineInOrder.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CombineInOrder.ValueTask.cs
@@ -1,0 +1,43 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously combines value-task-based results in input order into a single result.
+    /// </summary>
+    /// <param name="results">ValueTask results to combine.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static async ValueTask<Result> CombineInOrderAsync(params ValueTask<Result>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return CombineInOrder(resolved);
+    }
+
+    /// <summary>
+    /// Asynchronously combines value-task-based value results in input order into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">ValueTask results to combine.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static async ValueTask<Result<IEnumerable<TValue>>> CombineInOrderAsync<TValue>(params ValueTask<Result<TValue>>[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+
+        var resolved = new Result<TValue>[results.Length];
+        for (var i = 0; i < results.Length; i++)
+        {
+            resolved[i] = await results[i].ConfigureAwait(false);
+            ArgumentNullException.ThrowIfNull(resolved[i]);
+        }
+
+        return CombineInOrder(resolved);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CombineInOrder.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CombineInOrder.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Combines multiple results in order into a single result.
+    /// </summary>
+    /// <param name="results">Results to combine.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static Result CombineInOrder(params Result[] results)
+        => Combine(results);
+
+    /// <summary>
+    /// Combines multiple value results in order into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">Results to combine.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static Result<IEnumerable<TValue>> CombineInOrder<TValue>(params Result<TValue>[] results)
+        => Combine(results);
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineInOrderTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineInOrderTests.Task.cs
@@ -1,0 +1,74 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CombineInOrderTestsTask
+{
+    [Test]
+    public async Task CombineInOrderAsyncTaskReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            Task.FromResult(Result.Ok()),
+            Task.FromResult(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncTaskAggregatesErrorsFromAllFailedResults()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            Task.FromResult(Result.Fail("Failure 1")),
+            Task.FromResult(Result.Fail("Failure 2")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(Array.Empty<Task<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.CombineInOrderAsync((Task<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncTaskThrowsWhenTaskItemIsNull()
+    {
+        Task<Result>[] inputs = [Task.FromResult(Result.Ok()), null!];
+
+        var action = async () => await ResultExtensions.CombineInOrderAsync(inputs);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncTaskTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            Task.FromResult(Result.Ok(1)),
+            Task.FromResult(Result.Ok(2)));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncTaskTReturnsFailureAndAggregatesErrors()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            Task.FromResult(Result.Ok(1)),
+            Task.FromResult(Result.Fail<int>("Failure")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineInOrderTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineInOrderTests.ValueTask.cs
@@ -1,0 +1,64 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CombineInOrderTestsValueTask
+{
+    [Test]
+    public async Task CombineInOrderAsyncValueTaskReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            new ValueTask<Result>(Result.Ok()),
+            new ValueTask<Result>(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncValueTaskAggregatesErrorsFromAllFailedResults()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            new ValueTask<Result>(Result.Fail("Failure 1")),
+            new ValueTask<Result>(Result.Fail("Failure 2")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncValueTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(Array.Empty<ValueTask<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncValueTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.CombineInOrderAsync((ValueTask<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncValueTaskTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            new ValueTask<Result<int>>(Result.Ok(1)),
+            new ValueTask<Result<int>>(Result.Ok(2)));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task CombineInOrderAsyncValueTaskTReturnsFailureAndAggregatesErrors()
+    {
+        var output = await ResultExtensions.CombineInOrderAsync(
+            new ValueTask<Result<int>>(Result.Ok(1)),
+            new ValueTask<Result<int>>(Result.Fail<int>("Failure")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineInOrderTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CombineInOrderTests.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CombineInOrderTests
+{
+    [Test]
+    public void CombineInOrderReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = ResultExtensions.CombineInOrder(Result.Ok(), Result.Ok());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void CombineInOrderAggregatesErrorsFromAllFailedResults()
+    {
+        var output = ResultExtensions.CombineInOrder(Result.Fail("Failure 1"), Result.Fail("Failure 2"));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public void CombineInOrderReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = ResultExtensions.CombineInOrder();
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void CombineInOrderThrowsWhenResultsArrayIsNull()
+    {
+        var action = () => ResultExtensions.CombineInOrder(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CombineInOrderThrowsWhenResultItemIsNull()
+    {
+        Result?[] inputs = [Result.Ok(), null, Result.Fail("Failure")];
+
+        var action = () => ResultExtensions.CombineInOrder(inputs!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CombineInOrderTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = ResultExtensions.CombineInOrder(Result.Ok(1), Result.Ok(2));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public void CombineInOrderTReturnsFailureAndAggregatesErrors()
+    {
+        var output = ResultExtensions.CombineInOrder(Result.Ok(1), Result.Fail<int>("Failure"));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}


### PR DESCRIPTION
## Summary
- add `CombineInOrder` sync extensions for `Result` and `Result<T>`
- add `CombineInOrderAsync` overloads for `Task` and `ValueTask`
- add unit tests for sync/task/valuetask paths
- add README usage section for `CombineInOrder`

## Verification
- `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`
  - passed: 2700
  - failed: 0
  - skipped: 0

Closes #45