### PR TITLE
feat: add CompleteInOrder extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,30 @@ var asyncOutput = await ResultExtensions.CombineInOrderAsync(
 </details>
 
 <details>
+<summary><strong>CompleteInOrder</strong></summary>
+
+`CompleteInOrder` is an alias over `CombineInOrder` for ordered async result completion.
+For synchronous inputs, behavior matches `Combine`/`CombineInOrder`.
+For async (`Task`/`ValueTask`) inputs, results are awaited in input order before aggregation.
+
+```csharp
+var output = ResultExtensions.CompleteInOrder(
+    Result.Ok(),
+    Result.Fail("Validation failed"),
+    Result.Fail("Another error"));
+
+var outputWithValues = ResultExtensions.CompleteInOrder(
+    Result.Ok(1),
+    Result.Ok(2));
+
+var asyncOutput = await ResultExtensions.CompleteInOrderAsync(
+    Task.FromResult(Result.Ok()),
+    Task.FromResult(Result.Fail("Validation failed")));
+```
+
+</details>
+
+<details>
 <summary><strong>FirstFailureOrSuccess</strong></summary>
 
 `FirstFailureOrSuccess` provides CSharpFunctionalExtensions-style short-circuit failure selection.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CompleteInOrder.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CompleteInOrder.Task.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously completes task-based results in input order into a single result.
+    /// </summary>
+    /// <param name="results">Task results to complete.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static Task<Result> CompleteInOrderAsync(params Task<Result>[] results)
+        => CombineInOrderAsync(results);
+
+    /// <summary>
+    /// Asynchronously completes task-based value results in input order into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">Task results to complete.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static Task<Result<IEnumerable<TValue>>> CompleteInOrderAsync<TValue>(params Task<Result<TValue>>[] results)
+        => CombineInOrderAsync(results);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CompleteInOrder.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CompleteInOrder.ValueTask.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Asynchronously completes value-task-based results in input order into a single result.
+    /// </summary>
+    /// <param name="results">ValueTask results to complete.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static ValueTask<Result> CompleteInOrderAsync(params ValueTask<Result>[] results)
+        => CombineInOrderAsync(results);
+
+    /// <summary>
+    /// Asynchronously completes value-task-based value results in input order into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">ValueTask results to complete.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static ValueTask<Result<IEnumerable<TValue>>> CompleteInOrderAsync<TValue>(params ValueTask<Result<TValue>>[] results)
+        => CombineInOrderAsync(results);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CompleteInOrder.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/CompleteInOrder.cs
@@ -1,0 +1,21 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Completes multiple results in order into a single result.
+    /// </summary>
+    /// <param name="results">Results to complete.</param>
+    /// <returns>A merged result containing combined reasons.</returns>
+    public static Result CompleteInOrder(params Result[] results)
+        => CombineInOrder(results);
+
+    /// <summary>
+    /// Completes multiple value results in order into a single value result.
+    /// </summary>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <param name="results">Results to complete.</param>
+    /// <returns>A merged value result containing combined reasons and values when successful.</returns>
+    public static Result<IEnumerable<TValue>> CompleteInOrder<TValue>(params Result<TValue>[] results)
+        => CombineInOrder(results);
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompleteInOrderTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompleteInOrderTests.Task.cs
@@ -1,0 +1,74 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompleteInOrderTestsTask
+{
+    [Test]
+    public async Task CompleteInOrderAsyncTaskReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            Task.FromResult(Result.Ok()),
+            Task.FromResult(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncTaskAggregatesErrorsFromAllFailedResults()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            Task.FromResult(Result.Fail("Failure 1")),
+            Task.FromResult(Result.Fail("Failure 2")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(Array.Empty<Task<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.CompleteInOrderAsync((Task<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncTaskThrowsWhenTaskItemIsNull()
+    {
+        Task<Result>[] inputs = [Task.FromResult(Result.Ok()), null!];
+
+        var action = async () => await ResultExtensions.CompleteInOrderAsync(inputs);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncTaskTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            Task.FromResult(Result.Ok(1)),
+            Task.FromResult(Result.Ok(2)));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncTaskTReturnsFailureAndAggregatesErrors()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            Task.FromResult(Result.Ok(1)),
+            Task.FromResult(Result.Fail<int>("Failure")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompleteInOrderTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompleteInOrderTests.ValueTask.cs
@@ -1,0 +1,64 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompleteInOrderTestsValueTask
+{
+    [Test]
+    public async Task CompleteInOrderAsyncValueTaskReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            new ValueTask<Result>(Result.Ok()),
+            new ValueTask<Result>(Result.Ok()));
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncValueTaskAggregatesErrorsFromAllFailedResults()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            new ValueTask<Result>(Result.Fail("Failure 1")),
+            new ValueTask<Result>(Result.Fail("Failure 2")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncValueTaskReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(Array.Empty<ValueTask<Result>>());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncValueTaskThrowsWhenResultsArrayIsNull()
+    {
+        var action = async () => await ResultExtensions.CompleteInOrderAsync((ValueTask<Result>[])null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncValueTaskTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            new ValueTask<Result<int>>(Result.Ok(1)),
+            new ValueTask<Result<int>>(Result.Ok(2)));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public async Task CompleteInOrderAsyncValueTaskTReturnsFailureAndAggregatesErrors()
+    {
+        var output = await ResultExtensions.CompleteInOrderAsync(
+            new ValueTask<Result<int>>(Result.Ok(1)),
+            new ValueTask<Result<int>>(Result.Fail<int>("Failure")));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompleteInOrderTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/CompleteInOrderTests.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class CompleteInOrderTests
+{
+    [Test]
+    public void CompleteInOrderReturnsSuccessWhenAllResultsSuccessful()
+    {
+        var output = ResultExtensions.CompleteInOrder(Result.Ok(), Result.Ok());
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void CompleteInOrderAggregatesErrorsFromAllFailedResults()
+    {
+        var output = ResultExtensions.CompleteInOrder(Result.Fail("Failure 1"), Result.Fail("Failure 2"));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(e => e.Message == "Failure 1");
+        output.Errors.Should().Contain(e => e.Message == "Failure 2");
+    }
+
+    [Test]
+    public void CompleteInOrderReturnsSuccessWhenNoResultsProvided()
+    {
+        var output = ResultExtensions.CompleteInOrder();
+
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void CompleteInOrderThrowsWhenResultsArrayIsNull()
+    {
+        var action = () => ResultExtensions.CompleteInOrder(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CompleteInOrderThrowsWhenResultItemIsNull()
+    {
+        Result?[] inputs = [Result.Ok(), null, Result.Fail("Failure")];
+
+        var action = () => ResultExtensions.CompleteInOrder(inputs!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void CompleteInOrderTReturnsMergedValuesWhenAllResultsSuccessful()
+    {
+        var output = ResultExtensions.CompleteInOrder(Result.Ok(1), Result.Ok(2));
+
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Equal(1, 2);
+    }
+
+    [Test]
+    public void CompleteInOrderTReturnsFailureAndAggregatesErrors()
+    {
+        var output = ResultExtensions.CompleteInOrder(Result.Ok(1), Result.Fail<int>("Failure"));
+
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(e => e.Message == "Failure");
+    }
+}


### PR DESCRIPTION
## Summary
- add `CompleteInOrder` sync extensions for `Result` and `Result<T>`
- add `CompleteInOrderAsync` overloads for `Task` and `ValueTask`
- implement `CompleteInOrder*` as aliases over ordered `CombineInOrder*` behavior
- add unit tests for sync/task/valuetask paths
- add README usage section for `CompleteInOrder`

## Verification
- `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`
  - passed: 2760
  - failed: 0
  - skipped: 0

Closes #47