### PR TITLE
feat(map): add MapTry extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,30 @@ var output3 = await GetNumberAsync().MapAsync(MapValueTaskAsync);
 </details>
 
 <details>
+<summary><strong>MapTry</strong></summary>
+
+Creates a new Result from the return value of a function and converts thrown exceptions into failed Results.
+If the source Result is failed, its errors are preserved and the delegate is not executed.
+
+```csharp
+var output = Result.Ok(1)
+    .MapTry(value => int.Parse(value.ToString()));
+
+var outputWithCustomError = Result.Ok("42")
+    .MapTry(value => int.Parse(value), ex => $"Parsing failed: {ex.Message}");
+
+public Task<int> LoadNumberAsync()
+...
+var outputAsync = await Result.Ok()
+    .MapTryAsync(LoadNumberAsync);
+
+var outputFromTask = await GetNumberAsync()
+    .MapTryAsync(value => ValueTask.FromResult(value + 1));
+```
+
+</details>
+
+<details>
 <summary><strong>Select</strong></summary>
 
 LINQ-friendly alias for `Map`.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.Task.Left.cs
@@ -1,0 +1,43 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result with a synchronous function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">The mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async Task<Result<TValue>> MapTryAsync<TValue>(
+        this Task<Result> resultTask,
+        Func<TValue> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.InternalMapTry(func, errorHandler);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with a synchronous function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">The mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async Task<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.InternalMapTry(func, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.Task.Right.cs
@@ -1,0 +1,45 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps a successful result with an asynchronous task function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static Task<Result<TValue>> MapTryAsync<TValue>(
+        this Result result,
+        Func<Task<TValue>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Task.FromResult(Result.Fail<TValue>(result.Errors))
+            : TryAsync(func, errorHandler);
+    }
+
+    /// <summary>
+    /// Maps a successful result with an asynchronous task function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static Task<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Task<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Task.FromResult(Result.Fail<TValueOut>(result.Errors))
+            : TryAsync(() => func(result.Value), errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.Task.cs
@@ -1,0 +1,82 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous task function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async Task<Result<TValue>> MapTryAsync<TValue>(
+        this Task<Result> resultTask,
+        Func<Task<TValue>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous valuetask function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async Task<Result<TValue>> MapTryAsync<TValue>(
+        this Task<Result> resultTask,
+        Func<ValueTask<TValue>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous task function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async Task<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous valuetask function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">Task producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async Task<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.ValueTask.Left.cs
@@ -1,0 +1,43 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result with a synchronous function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">The mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async ValueTask<Result<TValue>> MapTryAsync<TValue>(
+        this ValueTask<Result> resultTask,
+        Func<TValue> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.InternalMapTry(func, errorHandler);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with a synchronous function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">The mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async ValueTask<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, TValueOut> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.InternalMapTry(func, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.ValueTask.Right.cs
@@ -1,0 +1,45 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps a successful result with an asynchronous valuetask function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static ValueTask<Result<TValue>> MapTryAsync<TValue>(
+        this Result result,
+        Func<ValueTask<TValue>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? ValueTask.FromResult(Result.Fail<TValue>(result.Errors))
+            : TryAsync(func, errorHandler);
+    }
+
+    /// <summary>
+    /// Maps a successful result with an asynchronous valuetask function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static ValueTask<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, ValueTask<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? ValueTask.FromResult(Result.Fail<TValueOut>(result.Errors))
+            : TryAsync(() => func(result.Value), errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.ValueTask.cs
@@ -1,0 +1,82 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous valuetask function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async ValueTask<Result<TValue>> MapTryAsync<TValue>(
+        this ValueTask<Result> resultTask,
+        Func<ValueTask<TValue>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous task function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async ValueTask<Result<TValue>> MapTryAsync<TValue>(
+        this ValueTask<Result> resultTask,
+        Func<Task<TValue>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous valuetask function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async ValueTask<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result with an asynchronous task function and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="resultTask">ValueTask producing the source result.</param>
+    /// <param name="func">The asynchronous mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A ValueTask producing the mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static async ValueTask<Result<TValueOut>> MapTryAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Task<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapTry.cs
@@ -1,0 +1,54 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps a successful result and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the mapped value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">The mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static Result<TValue> MapTry<TValue>(this Result result, Func<TValue> func, Func<Exception, string>? errorHandler = null)
+        => result.InternalMapTry(func, errorHandler);
+
+    /// <summary>
+    /// Maps a successful result and converts thrown exceptions into failed results.
+    /// </summary>
+    /// <typeparam name="TValue">The source value type.</typeparam>
+    /// <typeparam name="TValueOut">The type of the mapped value.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="func">The mapping function.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A mapped successful result, the original failure, or a failed result created from a thrown exception.</returns>
+    public static Result<TValueOut> MapTry<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, TValueOut> func,
+        Func<Exception, string>? errorHandler = null)
+        => result.InternalMapTry(func, errorHandler);
+
+    internal static Result<TValue> InternalMapTry<TValue>(
+        this Result result,
+        Func<TValue> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Result.Fail<TValue>(result.Errors)
+            : Try(func, errorHandler);
+    }
+
+    internal static Result<TValueOut> InternalMapTry<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, TValueOut> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Result.Fail<TValueOut>(result.Errors)
+            : Try(() => func(result.Value), errorHandler);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Base.cs
@@ -1,0 +1,116 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class MapTryTestsBase : TestBase
+{
+    protected const string TryExceptionMessage = "MapTry Exception Message";
+    protected const string CustomErrorMessage = "Custom MapTry Error Message";
+
+    protected class TValueMapped
+    {
+        public static readonly TValueMapped Value = new();
+    }
+
+    protected TValueMapped MapFunc()
+    {
+        FuncExecuted = true;
+        return TValueMapped.Value;
+    }
+
+    protected TValueMapped MapFunc(TValue _)
+    {
+        FuncExecuted = true;
+        return TValueMapped.Value;
+    }
+
+    protected TValueMapped ThrowMapFunc()
+    {
+        FuncExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected TValueMapped ThrowMapFunc(TValue _)
+    {
+        FuncExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Task<TValueMapped> TaskMapFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromResult(TValueMapped.Value);
+    }
+
+    protected Task<TValueMapped> TaskMapFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(TValueMapped.Value);
+    }
+
+    protected Task<TValueMapped> ThrowTaskMapFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromException<TValueMapped>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected Task<TValueMapped> ThrowTaskMapFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromException<TValueMapped>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask<TValueMapped> ValueTaskMapFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(TValueMapped.Value);
+    }
+
+    protected ValueTask<TValueMapped> ValueTaskMapFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(TValueMapped.Value);
+    }
+
+    protected ValueTask<TValueMapped> ThrowValueTaskMapFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromException<TValueMapped>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask<TValueMapped> ThrowValueTaskMapFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromException<TValueMapped>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected static string CustomErrorHandler(Exception _) => CustomErrorMessage;
+
+    protected void AssertSuccess(Result<TValueMapped> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValueMapped.Value);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertSourceFailure(Result<TValueMapped> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        FuncExecuted.Should().BeFalse();
+    }
+
+    protected void AssertDefaultFailure(Result<TValueMapped> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertCustomFailure(Result<TValueMapped> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+        FuncExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Task.Left.cs
@@ -1,0 +1,52 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTestsTaskLeft : MapTryTestsBase
+{
+    [Test]
+    public async Task MapTryAsyncTaskLeftReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await TaskFailResultAsync().MapTryAsync(MapFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskLeftSelectsNewResult()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(MapFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskLeftConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(ThrowMapFunc);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskLeftConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(ThrowMapFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskLeftTSelectsNewResult()
+    {
+        var output = await TaskOkResultTAsync().MapTryAsync(MapFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskLeftTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await TaskOkResultTAsync().MapTryAsync(ThrowMapFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Task.Right.cs
@@ -1,0 +1,52 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTestsTaskRight : MapTryTestsBase
+{
+    [Test]
+    public async Task MapTryAsyncTaskRightReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await Result.Fail(ErrorMessage).MapTryAsync(TaskMapFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskRightSelectsNewResult()
+    {
+        var output = await Result.Ok().MapTryAsync(TaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskRightConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await Result.Ok().MapTryAsync(ThrowTaskMapFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskRightConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok().MapTryAsync(ThrowTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskRightTSelectsNewResult()
+    {
+        var output = await Result.Ok(TValue.Value).MapTryAsync(TaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskRightTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok(TValue.Value).MapTryAsync(ThrowTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.Task.cs
@@ -1,0 +1,60 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTestsTask : MapTryTestsBase
+{
+    [Test]
+    public async Task MapTryAsyncTaskReturnsFailureAndDoesNotExecuteTaskFunc()
+    {
+        var output = await TaskFailResultAsync().MapTryAsync(TaskMapFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskSelectsNewResult()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(TaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskConvertsTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(ThrowTaskMapFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskWithValueTaskFuncSelectsNewResult()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskWithValueTaskFuncConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await TaskOkResultAsync().MapTryAsync(ThrowValueTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskTWithTaskFuncSelectsNewResult()
+    {
+        var output = await TaskOkResultTAsync().MapTryAsync(TaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncTaskTWithValueTaskFuncConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await TaskOkResultTAsync().MapTryAsync(ThrowValueTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.ValueTask.Left.cs
@@ -1,0 +1,52 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTestsValueTaskLeft : MapTryTestsBase
+{
+    [Test]
+    public async Task MapTryAsyncValueTaskLeftReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await ValueTaskFailResultAsync().MapTryAsync(MapFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskLeftSelectsNewResult()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(MapFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskLeftConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(ThrowMapFunc);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskLeftConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(ThrowMapFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskLeftTSelectsNewResult()
+    {
+        var output = await ValueTaskOkResultTAsync().MapTryAsync(MapFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskLeftTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ValueTaskOkResultTAsync().MapTryAsync(ThrowMapFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.ValueTask.Right.cs
@@ -1,0 +1,52 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTestsValueTaskRight : MapTryTestsBase
+{
+    [Test]
+    public async Task MapTryAsyncValueTaskRightReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = await Result.Fail(ErrorMessage).MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskRightSelectsNewResult()
+    {
+        var output = await Result.Ok().MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskRightConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await Result.Ok().MapTryAsync(ThrowValueTaskMapFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskRightConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok().MapTryAsync(ThrowValueTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskRightTSelectsNewResult()
+    {
+        var output = await Result.Ok(TValue.Value).MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskRightTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok(TValue.Value).MapTryAsync(ThrowValueTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.ValueTask.cs
@@ -1,0 +1,60 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTestsValueTask : MapTryTestsBase
+{
+    [Test]
+    public async Task MapTryAsyncValueTaskReturnsFailureAndDoesNotExecuteValueTaskFunc()
+    {
+        var output = await ValueTaskFailResultAsync().MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskSelectsNewResult()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskConvertsValueTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(ThrowValueTaskMapFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskWithTaskFuncSelectsNewResult()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(TaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskWithTaskFuncConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ValueTaskOkResultAsync().MapTryAsync(ThrowTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskTWithValueTaskFuncSelectsNewResult()
+    {
+        var output = await ValueTaskOkResultTAsync().MapTryAsync(ValueTaskMapFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task MapTryAsyncValueTaskTWithTaskFuncConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ValueTaskOkResultTAsync().MapTryAsync(ThrowTaskMapFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapTryTests.cs
@@ -1,0 +1,84 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapTryTests : MapTryTestsBase
+{
+    [Test]
+    public void MapTryReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail(ErrorMessage).MapTry(MapFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public void MapTrySelectsNewResult()
+    {
+        var output = Result.Ok().MapTry(MapFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public void MapTryConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok().MapTry(ThrowMapFunc);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public void MapTryConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok().MapTry(ThrowMapFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public void MapTryTReturnsFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail<TValue>(ErrorMessage).MapTry(MapFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public void MapTryTSelectsNewResult()
+    {
+        var output = Result.Ok(TValue.Value).MapTry(MapFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public void MapTryTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok(TValue.Value).MapTry(ThrowMapFunc);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public void MapTryTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok(TValue.Value).MapTry(ThrowMapFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public void MapTryThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok().MapTry((Func<TValueMapped>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void MapTryTThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).MapTry((Func<TValue, TValueMapped>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Add `MapTry` and `MapTryAsync` extension methods for `Result` and `Result<T>` across synchronous, `Task`, and `ValueTask` flows.

## Why
Issue `#56` requested CSharpFunctionalExtensions-style `MapTry` support while preserving this repository's existing async naming conventions.

## How to test
- Run `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`
- Confirm the new `MapTry` examples in `README.md` match the implemented API surface

## Risks
- The API adds a broad overload set, so overload resolution is the main regression area. The new tests cover sync, `Task`, and `ValueTask` combinations.

Closes #56