### PR TITLE
feat(map): add MapIf extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,30 @@ var output3 = await GetNumberAsync().MapAsync(MapValueTaskAsync);
 </details>
 
 <details>
+<summary><strong>MapIf</strong></summary>
+
+Conditionally maps a successful `Result<TValue>`.
+If the condition or predicate is not satisfied, it returns the original result unchanged.
+
+```csharp
+var output = Result.Ok(10)
+    .MapIf(true, value => value + 5);
+
+var output2 = Result.Ok(10)
+    .MapIf(value => value > 5, value => value * 2);
+
+public Task<int> IncrementAsync(int value)
+...
+var output3 = await Result.Ok(10)
+    .MapIfAsync(value => value > 5, IncrementAsync);
+
+var output4 = await GetNumberAsync()
+    .MapIfAsync(true, value => ValueTask.FromResult(value * 3));
+```
+
+</details>
+
+<details>
 <summary><strong>MapTry</strong></summary>
 
 Creates a new Result from the return value of a function and converts thrown exceptions into failed Results.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.Task.Left.cs
@@ -1,0 +1,33 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result value with a synchronous function when the supplied condition is true.
+    /// </summary>
+    public static async Task<Result<TValue>> MapIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapIf(condition, func);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with a synchronous function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static async Task<Result<TValue>> MapIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapIf(predicate, func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.Task.Right.cs
@@ -1,0 +1,33 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps a successful result value with an asynchronous task function when the supplied condition is true.
+    /// </summary>
+    public static Task<Result<TValue>> MapIfAsync<TValue>(
+        this Result<TValue> result,
+        bool condition,
+        Func<TValue, Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.MapAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Maps a successful result value with an asynchronous task function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static Task<Result<TValue>> MapIfAsync<TValue>(
+        this Result<TValue> result,
+        Func<TValue, bool> predicate,
+        Func<TValue, Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.MapAsync(func)
+            : Task.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.Task.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous task function when the supplied condition is true.
+    /// </summary>
+    public static async Task<Result<TValue>> MapIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous valuetask function when the supplied condition is true.
+    /// </summary>
+    public static async Task<Result<TValue>> MapIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous task function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static async Task<Result<TValue>> MapIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous valuetask function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static async Task<Result<TValue>> MapIfAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.ValueTask.Left.cs
@@ -1,0 +1,33 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result value with a synchronous function when the supplied condition is true.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapIf(condition, func);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with a synchronous function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapIf(predicate, func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.ValueTask.Right.cs
@@ -1,0 +1,33 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps a successful result value with an asynchronous valuetask function when the supplied condition is true.
+    /// </summary>
+    public static ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this Result<TValue> result,
+        bool condition,
+        Func<TValue, ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.MapAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Maps a successful result value with an asynchronous valuetask function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this Result<TValue> result,
+        Func<TValue, bool> predicate,
+        Func<TValue, ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.MapAsync(func)
+            : ValueTask.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.ValueTask.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous valuetask function when the supplied condition is true.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous task function when the supplied condition is true.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        bool condition,
+        Func<TValue, Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous valuetask function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, ValueTask<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps an awaited successful result value with an asynchronous task function when the supplied predicate evaluates to true.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapIfAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, bool> predicate,
+        Func<TValue, Task<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapIf.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps a successful result value when the supplied condition is true.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether mapping runs.</param>
+    /// <param name="func">Mapping function to execute when the condition is true.</param>
+    /// <returns>The original result when the condition is false; otherwise the result of applying <see cref="Map{TValue,TValueOut}(Result{TValue},Func{TValue,TValueOut})"/>.</returns>
+    public static Result<TValue> MapIf<TValue>(this Result<TValue> result, bool condition, Func<TValue, TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.Map(func) : result;
+    }
+
+    /// <summary>
+    /// Maps a successful result value when the supplied predicate evaluates to true.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether mapping runs.</param>
+    /// <param name="func">Mapping function to execute when the predicate is true.</param>
+    /// <returns>The original result when the source is failed or the predicate is false; otherwise the result of applying <see cref="Map{TValue,TValueOut}(Result{TValue},Func{TValue,TValueOut})"/>.</returns>
+    public static Result<TValue> MapIf<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, TValue> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.Map(func)
+            : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Base.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class MapIfTestsBase : TestBase
+{
+    protected static readonly TValue MappedValue = new();
+
+    protected bool PredicateExecuted { get; private set; }
+
+    protected TValue MapFunc(TValue value)
+    {
+        FuncExecuted = true;
+        return MappedValue;
+    }
+
+    protected Task<TValue> TaskMapFuncAsync(TValue value)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(MappedValue);
+    }
+
+    protected ValueTask<TValue> ValueTaskMapFuncAsync(TValue value)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(MappedValue);
+    }
+
+    protected bool TruePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected void AssertMapped(Result<TValue> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(MappedValue);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertSkipped(Result<TValue> source, Result<TValue> output, bool predicateExecuted)
+    {
+        PredicateExecuted.Should().Be(predicateExecuted);
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(source);
+    }
+
+    protected void AssertFailurePreserved(Result<TValue> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Task.Left.cs
@@ -1,0 +1,42 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTestsTaskLeft : MapIfTestsBase
+{
+    [Test]
+    public async Task MapIfTaskLeftConditionFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).MapIfAsync(false, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfTaskLeftConditionTrueMapsValue()
+    {
+        var output = await Task.FromResult(Result.Ok(TValue.Value)).MapIfAsync(true, MapFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfTaskLeftPredicateFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).MapIfAsync(FalsePredicate, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfTaskLeftPredicateOnFailedSourceSkipsPredicateAndMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await Task.FromResult(result).MapIfAsync(TruePredicate, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Task.Right.cs
@@ -1,0 +1,42 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTestsTaskRight : MapIfTestsBase
+{
+    [Test]
+    public async Task MapIfTaskRightConditionFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.MapIfAsync(false, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfTaskRightConditionTrueMapsValue()
+    {
+        var output = await Result.Ok(TValue.Value).MapIfAsync(true, TaskMapFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfTaskRightPredicateFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.MapIfAsync(FalsePredicate, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfTaskRightPredicateOnFailedSourceSkipsPredicateAndMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await result.MapIfAsync(TruePredicate, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.Task.cs
@@ -1,0 +1,80 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTestsTask : MapIfTestsBase
+{
+    [Test]
+    public async Task MapIfTaskConditionFalseReturnsOriginalResultAndSkipsTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).MapIfAsync(false, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfTaskConditionTrueMapsValueWithTaskFunc()
+    {
+        var output = await Task.FromResult(Result.Ok(TValue.Value)).MapIfAsync(true, TaskMapFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfTaskPredicateFalseReturnsOriginalResultAndSkipsTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).MapIfAsync(FalsePredicate, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfTaskPredicateOnFailedSourceSkipsPredicateAndTaskMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await Task.FromResult(result).MapIfAsync(TruePredicate, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfTaskConditionFalseReturnsOriginalResultAndSkipsValueTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).MapIfAsync(false, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfTaskConditionTrueMapsValueWithValueTaskFunc()
+    {
+        var output = await Task.FromResult(Result.Ok(TValue.Value)).MapIfAsync(true, ValueTaskMapFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfTaskPredicateFalseReturnsOriginalResultAndSkipsValueTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await Task.FromResult(result).MapIfAsync(FalsePredicate, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfTaskPredicateOnFailedSourceSkipsPredicateAndValueTaskMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await Task.FromResult(result).MapIfAsync(TruePredicate, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.ValueTask.Left.cs
@@ -1,0 +1,42 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTestsValueTaskLeft : MapIfTestsBase
+{
+    [Test]
+    public async Task MapIfValueTaskLeftConditionFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(false, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskLeftConditionTrueMapsValue()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Ok(TValue.Value)).MapIfAsync(true, MapFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskLeftPredicateFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(FalsePredicate, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskLeftPredicateOnFailedSourceSkipsPredicateAndMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(TruePredicate, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.ValueTask.Right.cs
@@ -1,0 +1,42 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTestsValueTaskRight : MapIfTestsBase
+{
+    [Test]
+    public async Task MapIfValueTaskRightConditionFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.MapIfAsync(false, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskRightConditionTrueMapsValue()
+    {
+        var output = await Result.Ok(TValue.Value).MapIfAsync(true, ValueTaskMapFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskRightPredicateFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.MapIfAsync(FalsePredicate, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskRightPredicateOnFailedSourceSkipsPredicateAndMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await result.MapIfAsync(TruePredicate, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.ValueTask.cs
@@ -1,0 +1,80 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTestsValueTask : MapIfTestsBase
+{
+    [Test]
+    public async Task MapIfValueTaskConditionFalseReturnsOriginalResultAndSkipsValueTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(false, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskConditionTrueMapsValueWithValueTaskFunc()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Ok(TValue.Value)).MapIfAsync(true, ValueTaskMapFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskPredicateFalseReturnsOriginalResultAndSkipsValueTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(FalsePredicate, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskPredicateOnFailedSourceSkipsPredicateAndValueTaskMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(TruePredicate, ValueTaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskConditionFalseReturnsOriginalResultAndSkipsTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(false, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskConditionTrueMapsValueWithTaskFunc()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Ok(TValue.Value)).MapIfAsync(true, TaskMapFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskPredicateFalseReturnsOriginalResultAndSkipsTaskMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(FalsePredicate, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public async Task MapIfValueTaskPredicateOnFailedSourceSkipsPredicateAndTaskMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await new ValueTask<Result<TValue>>(result).MapIfAsync(TruePredicate, TaskMapFuncAsync);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapIfTests.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapIfTests : MapIfTestsBase
+{
+    [Test]
+    public void MapIfConditionFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.MapIf(false, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public void MapIfConditionTrueMapsValue()
+    {
+        var output = Result.Ok(TValue.Value).MapIf(true, MapFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public void MapIfConditionTrueOnFailedSourcePreservesFailure()
+    {
+        var output = Result.Fail<TValue>(ErrorMessage).MapIf(true, MapFunc);
+
+        AssertFailurePreserved(output);
+    }
+
+    [Test]
+    public void MapIfPredicateFalseReturnsOriginalResultAndSkipsMap()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.MapIf(FalsePredicate, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public void MapIfPredicateTrueMapsValue()
+    {
+        var output = Result.Ok(TValue.Value).MapIf(TruePredicate, MapFunc);
+
+        PredicateExecuted.Should().BeTrue();
+        AssertMapped(output);
+    }
+
+    [Test]
+    public void MapIfPredicateOnFailedSourceSkipsPredicateAndMap()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = result.MapIf(TruePredicate, MapFunc);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+}


### PR DESCRIPTION
## What
Add `MapIf` and `MapIfAsync` extension methods for `Result<T>` across synchronous, `Task`, and `ValueTask` flows.

## Why
Issue `#55` requests CSharpFunctionalExtensions-style conditional mapping while preserving this repository's existing async naming conventions.

## How to test
- Run `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`
- Confirm the new `MapIf` examples in `README.md` match the implemented API surface

## Risks
- The added overload set is centered on `Result<T>` only; `TContext` overloads from CSharpFunctionalExtensions were intentionally not introduced because that pattern is not used elsewhere in this repository.

Closes #55