### PR TITLE
feat(maperror): add MapError compatibility methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,27 @@ var output4 = await GetNumberAsync()
 </details>
 
 <details>
+<summary><strong>MapError</strong></summary>
+
+`MapError` provides CSharpFunctionalExtensions-style naming over FluentResults `MapErrors`.
+Because FluentResults supports multiple `IError` values, `MapError` maps every error in a failed result and returns successful results unchanged.
+
+```csharp
+var output = Result.Fail("Validation failed")
+    .MapError(error => new Error($"Mapped: {error.Message}"));
+
+var outputWithValue = Result.Fail<int>("Validation failed")
+    .MapError(error => new Error($"Mapped: {error.Message}"));
+
+public Task<IError> MapErrorAsync(IError error)
+...
+var asyncOutput = await GetResultAsync()
+    .MapErrorAsync(MapErrorAsync);
+```
+
+</details>
+
+<details>
 <summary><strong>MapTry</strong></summary>
 
 Creates a new Result from the return value of a function and converts thrown exceptions into failed Results.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.Task.Left.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of an awaited failed result and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result> MapErrorAsync(this Task<Result> resultTask, Func<IError, IError> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapError(errorMapper);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result<TValue>> MapErrorAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IError, IError> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapError(errorMapper);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.Task.Right.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of a failed result with an asynchronous task mapper and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result> MapErrorAsync(this Result result, Func<IError, Task<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        return await result.InternalMapErrorAsync(error => new ValueTask<IError>(errorMapper(error))).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of a failed result with an asynchronous task mapper and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result<TValue>> MapErrorAsync<TValue>(
+        this Result<TValue> result,
+        Func<IError, Task<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        return await result.InternalMapErrorAsync(error => new ValueTask<IError>(errorMapper(error))).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.Task.cs
@@ -1,0 +1,54 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous task mapper and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result> MapErrorAsync(this Task<Result> resultTask, Func<IError, Task<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous valuetask mapper and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result> MapErrorAsync(
+        this Task<Result> resultTask,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.InternalMapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous task mapper and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result<TValue>> MapErrorAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IError, Task<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous valuetask mapper and returns successful results unchanged.
+    /// </summary>
+    public static async Task<Result<TValue>> MapErrorAsync<TValue>(
+        this Task<Result<TValue>> resultTask,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.InternalMapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.ValueTask.Left.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of an awaited failed result and returns successful results unchanged.
+    /// </summary>
+    public static async ValueTask<Result> MapErrorAsync(this ValueTask<Result> resultTask, Func<IError, IError> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapError(errorMapper);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result and returns successful results unchanged.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapErrorAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IError, IError> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.MapError(errorMapper);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.ValueTask.Right.cs
@@ -1,0 +1,18 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of a failed result with an asynchronous valuetask mapper and returns successful results unchanged.
+    /// </summary>
+    public static ValueTask<Result> MapErrorAsync(this Result result, Func<IError, ValueTask<IError>> errorMapper)
+        => result.InternalMapErrorAsync(errorMapper);
+
+    /// <summary>
+    /// Maps all errors of a failed result with an asynchronous valuetask mapper and returns successful results unchanged.
+    /// </summary>
+    public static ValueTask<Result<TValue>> MapErrorAsync<TValue>(
+        this Result<TValue> result,
+        Func<IError, ValueTask<IError>> errorMapper)
+        => result.InternalMapErrorAsync(errorMapper);
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.ValueTask.cs
@@ -1,0 +1,54 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous valuetask mapper and returns successful results unchanged.
+    /// </summary>
+    public static async ValueTask<Result> MapErrorAsync(
+        this ValueTask<Result> resultTask,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.InternalMapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous task mapper and returns successful results unchanged.
+    /// </summary>
+    public static async ValueTask<Result> MapErrorAsync(this ValueTask<Result> resultTask, Func<IError, Task<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous valuetask mapper and returns successful results unchanged.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapErrorAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.InternalMapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps all errors of an awaited failed result with an asynchronous task mapper and returns successful results unchanged.
+    /// </summary>
+    public static async ValueTask<Result<TValue>> MapErrorAsync<TValue>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<IError, Task<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.MapErrorAsync(errorMapper).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/MapError.cs
@@ -1,0 +1,79 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Maps all errors of a failed result and returns successful results unchanged.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="errorMapper">The error mapping function.</param>
+    /// <returns>The original successful result or a failed result with mapped errors.</returns>
+    public static Result MapError(this Result result, Func<IError, IError> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        return result.MapErrors(errorMapper);
+    }
+
+    /// <summary>
+    /// Maps all errors of a failed result and returns successful results unchanged.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="errorMapper">The error mapping function.</param>
+    /// <returns>The original successful result or a failed result with mapped errors.</returns>
+    public static Result<TValue> MapError<TValue>(this Result<TValue> result, Func<IError, IError> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        return result.MapErrors(errorMapper);
+    }
+
+    internal static async ValueTask<Result> InternalMapErrorAsync(
+        this Result result,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        if (result.IsSuccess)
+        {
+            return result;
+        }
+
+        var mappedErrors = await MapErrorsAsync(result.Errors, errorMapper).ConfigureAwait(false);
+        return new Result()
+            .WithErrors(mappedErrors)
+            .WithSuccesses(result.Successes);
+    }
+
+    internal static async ValueTask<Result<TValue>> InternalMapErrorAsync<TValue>(
+        this Result<TValue> result,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        ArgumentNullException.ThrowIfNull(errorMapper);
+
+        if (result.IsSuccess)
+        {
+            return result;
+        }
+
+        var mappedErrors = await MapErrorsAsync(result.Errors, errorMapper).ConfigureAwait(false);
+        return new Result<TValue>()
+            .WithErrors(mappedErrors)
+            .WithSuccesses(result.Successes);
+    }
+
+    private static async Task<List<IError>> MapErrorsAsync(
+        IEnumerable<IError> errors,
+        Func<IError, ValueTask<IError>> errorMapper)
+    {
+        var mappedErrors = new List<IError>();
+
+        foreach (var error in errors)
+        {
+            mappedErrors.Add(await errorMapper(error).ConfigureAwait(false));
+        }
+
+        return mappedErrors;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Base.cs
@@ -1,0 +1,80 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class MapErrorTestsBase : TestBase
+{
+    protected const string SecondErrorMessage = "Second Error Message";
+    protected const string SuccessMessage = "Success Message";
+    protected const string MappedErrorPrefix = "Mapped: ";
+
+    protected int MapperExecutionCount { get; private set; }
+
+    protected static Result FailedResult()
+        => Result.Fail(new Error(ErrorMessage))
+            .WithError(new Error(SecondErrorMessage))
+            .WithSuccess(SuccessMessage);
+
+    protected static Result<TValue> FailedResultT()
+        => Result.Fail<TValue>(new Error(ErrorMessage))
+            .WithError(new Error(SecondErrorMessage))
+            .WithSuccess(SuccessMessage);
+
+    protected static Result SucceededResult()
+        => Result.Ok().WithSuccess(SuccessMessage);
+
+    protected static Result<TValue> SucceededResultT()
+        => Result.Ok(TValue.Value).WithSuccess(SuccessMessage);
+
+    protected IError MapErrorFunc(IError error)
+    {
+        MapperExecutionCount++;
+        return new Error(MappedErrorPrefix + error.Message);
+    }
+
+    protected Task<IError> TaskMapErrorFuncAsync(IError error)
+    {
+        MapperExecutionCount++;
+        return Task.FromResult<IError>(new Error(MappedErrorPrefix + error.Message));
+    }
+
+    protected ValueTask<IError> ValueTaskMapErrorFuncAsync(IError error)
+    {
+        MapperExecutionCount++;
+        return ValueTask.FromResult<IError>(new Error(MappedErrorPrefix + error.Message));
+    }
+
+    protected void AssertUnchanged(Result source, Result output)
+    {
+        output.Should().BeSameAs(source);
+        MapperExecutionCount.Should().Be(0);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertUnchanged(Result<TValue> source, Result<TValue> output)
+    {
+        output.Should().BeSameAs(source);
+        MapperExecutionCount.Should().Be(0);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertMapped(Result output)
+    {
+        output.IsFailed.Should().BeTrue();
+        MapperExecutionCount.Should().Be(2);
+        output.Errors.Select(error => error.Message)
+            .Should()
+            .Equal(MappedErrorPrefix + ErrorMessage, MappedErrorPrefix + SecondErrorMessage);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertMapped(Result<TValue> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        MapperExecutionCount.Should().Be(2);
+        output.Errors.Select(error => error.Message)
+            .Should()
+            .Equal(MappedErrorPrefix + ErrorMessage, MappedErrorPrefix + SecondErrorMessage);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Task.Left.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTestsTaskLeft : MapErrorTestsBase
+{
+    [Test]
+    public async Task MapErrorAsyncTaskLeftReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = SucceededResult();
+
+        var output = await Task.FromResult(result).MapErrorAsync(MapErrorFunc);
+
+        AssertUnchanged(result, output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskLeftMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await Task.FromResult(FailedResult()).MapErrorAsync(MapErrorFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskLeftTMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await Task.FromResult(FailedResultT()).MapErrorAsync(MapErrorFunc);
+
+        AssertMapped(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Task.Right.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTestsTaskRight : MapErrorTestsBase
+{
+    [Test]
+    public async Task MapErrorAsyncTaskRightReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = SucceededResult();
+
+        var output = await result.MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertUnchanged(result, output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskRightMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await FailedResult().MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskRightTMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await FailedResultT().MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskRightThrowsWhenMapperIsNull()
+    {
+        var action = () => Result.Ok().MapErrorAsync((Func<IError, Task<IError>>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.Task.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTestsTask : MapErrorTestsBase
+{
+    [Test]
+    public async Task MapErrorAsyncTaskMapsAllErrorsWithTaskMapper()
+    {
+        var output = await Task.FromResult(FailedResult()).MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskMapsAllErrorsWithValueTaskMapper()
+    {
+        var output = await Task.FromResult(FailedResult()).MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskTMapsAllErrorsWithTaskMapper()
+    {
+        var output = await Task.FromResult(FailedResultT()).MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncTaskTMapsAllErrorsWithValueTaskMapper()
+    {
+        var output = await Task.FromResult(FailedResultT()).MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.ValueTask.Left.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTestsValueTaskLeft : MapErrorTestsBase
+{
+    [Test]
+    public async Task MapErrorAsyncValueTaskLeftReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = SucceededResult();
+
+        var output = await ValueTask.FromResult(result).MapErrorAsync(MapErrorFunc);
+
+        AssertUnchanged(result, output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskLeftMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await ValueTask.FromResult(FailedResult()).MapErrorAsync(MapErrorFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskLeftTMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await ValueTask.FromResult(FailedResultT()).MapErrorAsync(MapErrorFunc);
+
+        AssertMapped(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.ValueTask.Right.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTestsValueTaskRight : MapErrorTestsBase
+{
+    [Test]
+    public async Task MapErrorAsyncValueTaskRightReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = SucceededResult();
+
+        var output = await result.MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertUnchanged(result, output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskRightMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await FailedResult().MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskRightTMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = await FailedResultT().MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.ValueTask.cs
@@ -1,0 +1,36 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTestsValueTask : MapErrorTestsBase
+{
+    [Test]
+    public async Task MapErrorAsyncValueTaskMapsAllErrorsWithValueTaskMapper()
+    {
+        var output = await ValueTask.FromResult(FailedResult()).MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskMapsAllErrorsWithTaskMapper()
+    {
+        var output = await ValueTask.FromResult(FailedResult()).MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskTMapsAllErrorsWithValueTaskMapper()
+    {
+        var output = await ValueTask.FromResult(FailedResultT()).MapErrorAsync(ValueTaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public async Task MapErrorAsyncValueTaskTMapsAllErrorsWithTaskMapper()
+    {
+        var output = await ValueTask.FromResult(FailedResultT()).MapErrorAsync(TaskMapErrorFuncAsync);
+
+        AssertMapped(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/MapErrorTests.cs
@@ -1,0 +1,56 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class MapErrorTests : MapErrorTestsBase
+{
+    [Test]
+    public void MapErrorReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = SucceededResult();
+
+        var output = result.MapError(MapErrorFunc);
+
+        AssertUnchanged(result, output);
+    }
+
+    [Test]
+    public void MapErrorMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = FailedResult().MapError(MapErrorFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public void MapErrorTReturnsOriginalResultWhenSourceIsSuccessful()
+    {
+        var result = SucceededResultT();
+
+        var output = result.MapError(MapErrorFunc);
+
+        AssertUnchanged(result, output);
+    }
+
+    [Test]
+    public void MapErrorTMapsAllErrorsAndPreservesSuccesses()
+    {
+        var output = FailedResultT().MapError(MapErrorFunc);
+
+        AssertMapped(output);
+    }
+
+    [Test]
+    public void MapErrorThrowsWhenMapperIsNull()
+    {
+        var action = () => Result.Ok().MapError((Func<IError, IError>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void MapErrorTThrowsWhenMapperIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).MapError((Func<IError, IError>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- add `MapError` aliases for `Result` and `Result<T>` over FluentResults `MapErrors`
- add `MapErrorAsync` overloads for direct results plus `Task<Result>` / `ValueTask<Result>` wrappers
- add unit tests covering success passthrough, multi-error mapping, success preservation, null guards, and async combinations
- document `MapError` usage in `README.md`

## Why
- add a CSharpFunctionalExtensions-style `MapError` surface for FluentResults consumers
- keep the library's async naming and overload conventions consistent with existing methods
- addresses issue #54

## How to test
- `dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln`

## Risks
- `MapError` follows FluentResults semantics and maps every `IError`, which differs from CSharpFunctionalExtensions' single-error model
- no known migration risk; this is an additive compatibility API

Closes #54