### PR TITLE
ci: allow workflow contents write permission

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ on:
       - "**.md"
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow permissions in uild.yaml
- change contents permission from ead to write

## Why
- enables workflow operations that require write access to repository contents

## Testing
- not run (workflow permission-only change)