### PR TITLE
feat(bindif): add conditional bind methods with async overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ await Result.Ok().FinallyAsync(OnBothAsync);
 </details>
 
 <details>
+<summary><strong>BindIf</strong></summary>
+
+Conditionally executes `Bind` logic.
+If the condition/predicate is not satisfied, it returns the original result unchanged.
+
+```csharp
+var output = Result.Ok(10)
+    .BindIf(true, value => Result.Ok(value + 5));
+
+var output2 = Result.Ok(10)
+    .BindIf(value => value > 5, value => Result.Ok(value * 2));
+
+public Task<Result<int>> IncrementAsync(int value)
+...
+var output3 = await Result.Ok(10)
+    .BindIfAsync(value => value > 5, IncrementAsync);
+
+var output4 = await GetNumberAsync()
+    .BindIfAsync(true, value => ValueTask.FromResult(Result.Ok(value * 3)));
+```
+
+</details>
+
+<details>
 <summary><strong>Tap</strong></summary>
 
 Executes an action if the result is successful and return the original result.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.Task.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result> BindIfAsync(this Task<Result> resultTask, bool condition, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(condition, func);
+    }
+
+    public static async Task<Result<TValue>> BindIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<TValue, Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(condition, func);
+    }
+
+    public static async Task<Result> BindIfAsync(this Task<Result> resultTask, Func<bool> predicate, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(predicate, func);
+    }
+
+    public static async Task<Result<TValue>> BindIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(predicate, func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.Task.Right.cs
@@ -1,0 +1,42 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static Task<Result> BindIfAsync(this Result result, bool condition, Func<Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition
+            ? result.BindAsync(func)
+            : Task.FromResult(result);
+    }
+
+    public static Task<Result<TValue>> BindIfAsync<TValue>(this Result<TValue> result, bool condition, Func<TValue, Task<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition
+            ? result.BindAsync(func)
+            : Task.FromResult(result);
+    }
+
+    public static Task<Result> BindIfAsync(this Result result, Func<bool> predicate, Func<Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate()
+            ? result.BindAsync(func)
+            : Task.FromResult(result);
+    }
+
+    public static Task<Result<TValue>> BindIfAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, Task<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.BindAsync(func)
+            : Task.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.Task.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result> BindIfAsync(this Task<Result> resultTask, bool condition, Func<Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValue>> BindIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<TValue, Task<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    public static async Task<Result> BindIfAsync(this Task<Result> resultTask, Func<bool> predicate, Func<Task<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValue>> BindIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Task<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(predicate, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.ValueTask.Left.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result> BindIfAsync(this ValueTask<Result> resultTask, bool condition, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(condition, func);
+    }
+
+    public static async ValueTask<Result<TValue>> BindIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<TValue, Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(condition, func);
+    }
+
+    public static async ValueTask<Result> BindIfAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(predicate, func);
+    }
+
+    public static async ValueTask<Result<TValue>> BindIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindIf(predicate, func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.ValueTask.Right.cs
@@ -1,0 +1,42 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static ValueTask<Result> BindIfAsync(this Result result, bool condition, Func<ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition
+            ? result.BindAsync(func)
+            : ValueTask.FromResult(result);
+    }
+
+    public static ValueTask<Result<TValue>> BindIfAsync<TValue>(this Result<TValue> result, bool condition, Func<TValue, ValueTask<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition
+            ? result.BindAsync(func)
+            : ValueTask.FromResult(result);
+    }
+
+    public static ValueTask<Result> BindIfAsync(this Result result, Func<bool> predicate, Func<ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate()
+            ? result.BindAsync(func)
+            : ValueTask.FromResult(result);
+    }
+
+    public static ValueTask<Result<TValue>> BindIfAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, ValueTask<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.BindAsync(func)
+            : ValueTask.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.ValueTask.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result> BindIfAsync(this ValueTask<Result> resultTask, bool condition, Func<ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValue>> BindIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<TValue, ValueTask<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> BindIfAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Func<ValueTask<Result>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValue>> BindIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, ValueTask<Result<TValue>>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindIfAsync(predicate, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindIf.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Conditionally binds the result with a synchronous function.
+    /// </summary>
+    public static Result BindIf(this Result result, bool condition, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.Bind(func) : result;
+    }
+
+    /// <summary>
+    /// Conditionally binds the result value with a synchronous function.
+    /// </summary>
+    public static Result<TValue> BindIf<TValue>(this Result<TValue> result, bool condition, Func<TValue, Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.Bind(func) : result;
+    }
+
+    /// <summary>
+    /// Binds the result with a synchronous function when predicate evaluates to true.
+    /// </summary>
+    public static Result BindIf(this Result result, Func<bool> predicate, Func<Result> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate()
+            ? result.Bind(func)
+            : result;
+    }
+
+    /// <summary>
+    /// Binds the result value with a synchronous function when predicate evaluates to true.
+    /// </summary>
+    public static Result<TValue> BindIf<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, Result<TValue>> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.Bind(func)
+            : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Base.cs
@@ -1,0 +1,87 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class BindIfTestsBase : TestBase
+{
+    protected static readonly TValue BoundValue = new();
+    protected bool PredicateExecuted { get; private set; }
+
+    protected bool TruePredicate()
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate()
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected bool TruePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected Result OkFunc()
+    {
+        FuncExecuted = true;
+        return Result.Ok();
+    }
+
+    protected Task<Result> TaskOkFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok());
+    }
+
+    protected ValueTask<Result> ValueTaskOkFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok());
+    }
+
+    protected Result<TValue> BindToBoundValue(TValue value)
+    {
+        FuncExecuted = true;
+        return Result.Ok(BoundValue);
+    }
+
+    protected Task<Result<TValue>> TaskBindToBoundValueAsync(TValue value)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok(BoundValue));
+    }
+
+    protected ValueTask<Result<TValue>> ValueTaskBindToBoundValueAsync(TValue value)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok(BoundValue));
+    }
+
+    protected Result<TValue> FailBind(TValue value)
+    {
+        FuncExecuted = true;
+        return Result.Fail<TValue>(ErrorMessage);
+    }
+
+    protected Task<Result<TValue>> TaskFailBindAsync(TValue value)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Fail<TValue>(ErrorMessage));
+    }
+
+    protected ValueTask<Result<TValue>> ValueTaskFailBindAsync(TValue value)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Fail<TValue>(ErrorMessage));
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Task.Left.cs
@@ -1,0 +1,49 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTestsTaskLeft : BindIfTestsBase
+{
+    [Test]
+    public async Task BindIfTaskLeftResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await Task.FromResult(result).BindIfAsync(false, OkFunc);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfTaskLeftResultPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await Task.FromResult(result).BindIfAsync(FalsePredicate, OkFunc);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfTaskLeftResultTConditionTrueReturnsBoundResult()
+    {
+        var output = await Task.FromResult(Result.Ok(TValue.Value)).BindIfAsync(true, BindToBoundValue);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public async Task BindIfTaskLeftResultTPredicateOnFailedSourceSkipsPredicateAndFunc()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await Task.FromResult(result).BindIfAsync(TruePredicate, BindToBoundValue);
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Task.Right.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTestsTaskRight : BindIfTestsBase
+{
+    [Test]
+    public async Task BindIfTaskRightResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await result.BindIfAsync(false, TaskOkFuncAsync);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfTaskRightResultPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await result.BindIfAsync(FalsePredicate, TaskOkFuncAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfTaskRightResultTConditionTrueReturnsBoundResult()
+    {
+        var output = await Result.Ok(TValue.Value).BindIfAsync(true, TaskBindToBoundValueAsync);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public async Task BindIfTaskRightResultTPredicateOnFailedSourceSkipsPredicateAndFunc()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await result.BindIfAsync(TruePredicate, TaskBindToBoundValueAsync);
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.Task.cs
@@ -1,0 +1,47 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTestsTask : BindIfTestsBase
+{
+    [Test]
+    public async Task BindIfTaskResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await Task.FromResult(result).BindIfAsync(false, TaskOkFuncAsync);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfTaskResultPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await Task.FromResult(result).BindIfAsync(FalsePredicate, TaskOkFuncAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfTaskResultTConditionTrueReturnsBoundResult()
+    {
+        var output = await Task.FromResult(Result.Ok(TValue.Value)).BindIfAsync(true, TaskBindToBoundValueAsync);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public async Task BindIfTaskResultTConditionTruePropagatesFailure()
+    {
+        var output = await Task.FromResult(Result.Ok(TValue.Value)).BindIfAsync(true, TaskFailBindAsync);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.ValueTask.Left.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTestsValueTaskLeft : BindIfTestsBase
+{
+    [Test]
+    public async Task BindIfValueTaskLeftResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await new ValueTask<Result>(result).BindIfAsync(false, OkFunc);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskLeftResultPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await new ValueTask<Result>(result).BindIfAsync(FalsePredicate, OkFunc);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskLeftResultTConditionTrueReturnsBoundResult()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Ok(TValue.Value)).BindIfAsync(true, BindToBoundValue);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskLeftResultTPredicateOnFailedSourceSkipsPredicateAndFunc()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await new ValueTask<Result<TValue>>(result).BindIfAsync(TruePredicate, BindToBoundValue);
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.ValueTask.Right.cs
@@ -1,0 +1,50 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTestsValueTaskRight : BindIfTestsBase
+{
+    [Test]
+    public async Task BindIfValueTaskRightResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await result.BindIfAsync(false, ValueTaskOkFuncAsync);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskRightResultPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await result.BindIfAsync(FalsePredicate, ValueTaskOkFuncAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskRightResultTConditionTrueReturnsBoundResult()
+    {
+        var output = await Result.Ok(TValue.Value).BindIfAsync(true, ValueTaskBindToBoundValueAsync);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskRightResultTPredicateOnFailedSourceSkipsPredicateAndFunc()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = await result.BindIfAsync(TruePredicate, ValueTaskBindToBoundValueAsync);
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.ValueTask.cs
@@ -1,0 +1,47 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTestsValueTask : BindIfTestsBase
+{
+    [Test]
+    public async Task BindIfValueTaskResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await new ValueTask<Result>(result).BindIfAsync(false, ValueTaskOkFuncAsync);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskResultPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = await new ValueTask<Result>(result).BindIfAsync(FalsePredicate, ValueTaskOkFuncAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskResultTConditionTrueReturnsBoundResult()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Ok(TValue.Value)).BindIfAsync(true, ValueTaskBindToBoundValueAsync);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public async Task BindIfValueTaskResultTConditionTruePropagatesFailure()
+    {
+        var output = await new ValueTask<Result<TValue>>(Result.Ok(TValue.Value)).BindIfAsync(true, ValueTaskFailBindAsync);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindIfTests.cs
@@ -1,0 +1,69 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindIfTests : BindIfTestsBase
+{
+    [Test]
+    public void BindIfResultConditionFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok();
+
+        var output = result.BindIf(false, OkFunc);
+
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public void BindIfResultConditionTrueExecutesFuncAndReturnsBoundResult()
+    {
+        var output = Result.Ok().BindIf(true, OkFunc);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void BindIfResultPredicateOnFailedSourceSkipsPredicateAndFunc()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        var output = result.BindIf(TruePredicate, OkFunc);
+
+        PredicateExecuted.Should().BeFalse();
+        FuncExecuted.Should().BeFalse();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+
+    [Test]
+    public void BindIfResultTPredicateFalseReturnsOriginalResultAndSkipsFunc()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.BindIf(FalsePredicate, BindToBoundValue);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public void BindIfResultTPredicateTrueReturnsBoundResult()
+    {
+        var output = Result.Ok(TValue.Value).BindIf(TruePredicate, BindToBoundValue);
+
+        PredicateExecuted.Should().BeTrue();
+        FuncExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(BoundValue);
+    }
+
+    [Test]
+    public void BindIfResultTConditionTruePropagatesFuncFailure()
+    {
+        var output = Result.Ok(TValue.Value).BindIf(true, FailBind);
+
+        FuncExecuted.Should().BeTrue();
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}


### PR DESCRIPTION
## What
Implement issue #38 by adding BindIf support aligned with CSharpFunctionalExtensions and existing project conventions.

## Why
BindIf is missing in this repository and cannot be fully replaced by CheckIf/MapIf because it represents conditional bind semantics with failure propagation.

## How to test
- Run: dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln
- Expected: all tests pass for net8/net9/net10.

## Risks
- API surface increase (new overloads) can raise ambiguity risk in unusual call sites, but signatures follow existing naming/overload patterns.

Closes #38