### PR TITLE
feat(bindtry): add bind with exception handling overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ var output4 = await GetNumberAsync()
 </details>
 
 <details>
+<summary><strong>BindTry</strong></summary>
+
+Executes `Bind` logic for successful results and converts thrown exceptions into failed results.
+If the source result is already failed, the original failure is preserved and the delegate is not executed.
+
+```csharp
+var output = Result.Ok(10)
+    .BindTry(value => Result.Ok(value + 5));
+
+var output2 = Result.Ok(10)
+    .BindTry(
+        value => Result.Ok(int.Parse(value.ToString())),
+        ex => $"Bind failed: {ex.Message}");
+
+public Task<Result<int>> IncrementAsync(int value)
+...
+var output3 = await Result.Ok(10)
+    .BindTryAsync(IncrementAsync);
+
+var output4 = await GetNumberAsync()
+    .BindTryAsync(value => ValueTask.FromResult(Result.Ok(value * 3)));
+```
+
+</details>
+
+<details>
 <summary><strong>Tap</strong></summary>
 
 Executes an action if the result is successful and return the original result.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.Task.Left.cs
@@ -1,0 +1,39 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result> BindTryAsync(this Task<Result> resultTask, Func<Result> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+
+    public static async Task<Result<TValue>> BindTryAsync<TValue>(this Task<Result> resultTask, Func<Result<TValue>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+
+    public static async Task<Result> BindTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Result> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+
+    public static async Task<Result<TValueOut>> BindTryAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Result<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.Task.Right.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result> BindTryAsync(this Result result, Func<Task<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail(result.Errors);
+        }
+
+        var output = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+
+    public static async Task<Result<TValue>> BindTryAsync<TValue>(this Result result, Func<Task<Result<TValue>>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValue>(result.Errors);
+        }
+
+        var output = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+
+    public static async Task<Result> BindTryAsync<TValue>(this Result<TValue> result, Func<TValue, Task<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail(result.Errors);
+        }
+
+        var output = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+
+    public static async Task<Result<TValueOut>> BindTryAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Task<Result<TValueOut>>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValueOut>(result.Errors);
+        }
+
+        var output = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.Task.cs
@@ -1,0 +1,39 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result> BindTryAsync(this Task<Result> resultTask, Func<Task<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValue>> BindTryAsync<TValue>(this Task<Result> resultTask, Func<Task<Result<TValue>>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    public static async Task<Result> BindTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValueOut>> BindTryAsync<TValue, TValueOut>(
+        this Task<Result<TValue>> resultTask,
+        Func<TValue, Task<Result<TValueOut>>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.ValueTask.Left.cs
@@ -1,0 +1,39 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result> BindTryAsync(this ValueTask<Result> resultTask, Func<Result> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+
+    public static async ValueTask<Result<TValue>> BindTryAsync<TValue>(this ValueTask<Result> resultTask, Func<Result<TValue>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+
+    public static async ValueTask<Result> BindTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, Result> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+
+    public static async ValueTask<Result<TValueOut>> BindTryAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, Result<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindTry(func, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.ValueTask.Right.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result> BindTryAsync(this Result result, Func<ValueTask<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail(result.Errors);
+        }
+
+        var output = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+
+    public static async ValueTask<Result<TValue>> BindTryAsync<TValue>(this Result result, Func<ValueTask<Result<TValue>>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValue>(result.Errors);
+        }
+
+        var output = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+
+    public static async ValueTask<Result> BindTryAsync<TValue>(this Result<TValue> result, Func<TValue, ValueTask<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail(result.Errors);
+        }
+
+        var output = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+
+    public static async ValueTask<Result<TValueOut>> BindTryAsync<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, ValueTask<Result<TValueOut>>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValueOut>(result.Errors);
+        }
+
+        var output = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return output.Bind(static inner => inner);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.ValueTask.cs
@@ -1,0 +1,39 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result> BindTryAsync(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValue>> BindTryAsync<TValue>(this ValueTask<Result> resultTask, Func<ValueTask<Result<TValue>>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result> BindTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, ValueTask<Result>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValueOut>> BindTryAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue>> resultTask,
+        Func<TValue, ValueTask<Result<TValueOut>>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindTryAsync(func, errorHandler).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindTry.cs
@@ -1,0 +1,70 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Binds a successful result and converts thrown exceptions into failed results.
+    /// </summary>
+    public static Result BindTry(this Result result, Func<Result> func, Func<Exception, string>? errorHandler = null)
+        => result.InternalBindTry(func, errorHandler);
+
+    /// <summary>
+    /// Binds a successful result and converts thrown exceptions into failed results.
+    /// </summary>
+    public static Result<TValue> BindTry<TValue>(this Result result, Func<Result<TValue>> func, Func<Exception, string>? errorHandler = null)
+        => result.InternalBindTry(func, errorHandler);
+
+    /// <summary>
+    /// Binds a successful result value and converts thrown exceptions into failed results.
+    /// </summary>
+    public static Result BindTry<TValue>(this Result<TValue> result, Func<TValue, Result> func, Func<Exception, string>? errorHandler = null)
+        => result.InternalBindTry(func, errorHandler);
+
+    /// <summary>
+    /// Binds a successful result value and converts thrown exceptions into failed results.
+    /// </summary>
+    public static Result<TValueOut> BindTry<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Result<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+        => result.InternalBindTry(func, errorHandler);
+
+    internal static Result InternalBindTry(this Result result, Func<Result> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? result
+            : Try(func, errorHandler).Bind(static output => output);
+    }
+
+    internal static Result<TValue> InternalBindTry<TValue>(this Result result, Func<Result<TValue>> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Result.Fail<TValue>(result.Errors)
+            : Try(func, errorHandler).Bind(static output => output);
+    }
+
+    internal static Result InternalBindTry<TValue>(this Result<TValue> result, Func<TValue, Result> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Result.Fail(result.Errors)
+            : Try(() => func(result.Value), errorHandler).Bind(static output => output);
+    }
+
+    internal static Result<TValueOut> InternalBindTry<TValue, TValueOut>(
+        this Result<TValue> result,
+        Func<TValue, Result<TValueOut>> func,
+        Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsFailed
+            ? Result.Fail<TValueOut>(result.Errors)
+            : Try(() => func(result.Value), errorHandler).Bind(static output => output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Base.cs
@@ -1,0 +1,239 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class BindTryTestsBase : TestBase
+{
+    protected const string TryExceptionMessage = "BindTry Exception Message";
+    protected const string CustomErrorMessage = "Custom BindTry Error Message";
+
+    protected class TValueMapped
+    {
+        public static readonly TValueMapped Value = new();
+    }
+
+    protected Result OkResultFunc()
+    {
+        FuncExecuted = true;
+        return Result.Ok();
+    }
+
+    protected Result FailResultFunc()
+    {
+        FuncExecuted = true;
+        return Result.Fail(ErrorMessage);
+    }
+
+    protected Result ThrowResultFunc()
+    {
+        FuncExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Result<TValueMapped> OkResultTFunc()
+    {
+        FuncExecuted = true;
+        return Result.Ok(TValueMapped.Value);
+    }
+
+    protected Result<TValueMapped> FailResultTFunc()
+    {
+        FuncExecuted = true;
+        return Result.Fail<TValueMapped>(ErrorMessage);
+    }
+
+    protected Result<TValueMapped> ThrowResultTFunc()
+    {
+        FuncExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Result OkResultFromTFunc(TValue _)
+    {
+        FuncExecuted = true;
+        return Result.Ok();
+    }
+
+    protected Result FailResultFromTFunc(TValue _)
+    {
+        FuncExecuted = true;
+        return Result.Fail(ErrorMessage);
+    }
+
+    protected Result ThrowResultFromTFunc(TValue _)
+    {
+        FuncExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Result<TValueMapped> OkResultTFromTFunc(TValue _)
+    {
+        FuncExecuted = true;
+        return Result.Ok(TValueMapped.Value);
+    }
+
+    protected Result<TValueMapped> FailResultTFromTFunc(TValue _)
+    {
+        FuncExecuted = true;
+        return Result.Fail<TValueMapped>(ErrorMessage);
+    }
+
+    protected Result<TValueMapped> ThrowResultTFromTFunc(TValue _)
+    {
+        FuncExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Task<Result> TaskOkResultFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok());
+    }
+
+    protected Task<Result> ThrowTaskResultFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromException<Result>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected Task<Result<TValueMapped>> TaskOkResultTFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok(TValueMapped.Value));
+    }
+
+    protected Task<Result<TValueMapped>> ThrowTaskResultTFuncAsync()
+    {
+        FuncExecuted = true;
+        return Task.FromException<Result<TValueMapped>>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected Task<Result> TaskOkResultFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok());
+    }
+
+    protected Task<Result> ThrowTaskResultFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromException<Result>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected Task<Result<TValueMapped>> TaskOkResultTFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromResult(Result.Ok(TValueMapped.Value));
+    }
+
+    protected Task<Result<TValueMapped>> ThrowTaskResultTFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return Task.FromException<Result<TValueMapped>>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask<Result> ValueTaskOkResultFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok());
+    }
+
+    protected ValueTask<Result> ThrowValueTaskResultFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromException<Result>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask<Result<TValueMapped>> ValueTaskOkResultTFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok(TValueMapped.Value));
+    }
+
+    protected ValueTask<Result<TValueMapped>> ThrowValueTaskResultTFuncAsync()
+    {
+        FuncExecuted = true;
+        return ValueTask.FromException<Result<TValueMapped>>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask<Result> ValueTaskOkResultFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok());
+    }
+
+    protected ValueTask<Result> ThrowValueTaskResultFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromException<Result>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask<Result<TValueMapped>> ValueTaskOkResultTFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromResult(Result.Ok(TValueMapped.Value));
+    }
+
+    protected ValueTask<Result<TValueMapped>> ThrowValueTaskResultTFromTFuncAsync(TValue _)
+    {
+        FuncExecuted = true;
+        return ValueTask.FromException<Result<TValueMapped>>(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected static string CustomErrorHandler(Exception _) => CustomErrorMessage;
+
+    protected void AssertSuccess(Result output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertSuccess(Result<TValueMapped> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeSameAs(TValueMapped.Value);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertSourceFailure(Result output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        FuncExecuted.Should().BeFalse();
+    }
+
+    protected void AssertSourceFailure(Result<TValueMapped> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        FuncExecuted.Should().BeFalse();
+    }
+
+    protected void AssertDefaultFailure(Result output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertDefaultFailure(Result<TValueMapped> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == TryExceptionMessage);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertCustomFailure(Result output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertCustomFailure(Result<TValueMapped> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == CustomErrorMessage);
+        FuncExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Task.Left.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTestsTaskLeft : BindTryTestsBase
+{
+    [Test]
+    public async Task BindTryAsyncTaskLeftReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = await TaskFailResultAsync().BindTryAsync(OkResultFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskLeftSelectsNewTypedResult()
+    {
+        var output = await TaskOkResultAsync().BindTryAsync(OkResultTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskLeftConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await TaskOkResultAsync().BindTryAsync(ThrowResultFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskLeftTSelectsNewTypedResult()
+    {
+        var output = await TaskOkResultTAsync().BindTryAsync(OkResultTFromTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskLeftTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await TaskOkResultTAsync().BindTryAsync(ThrowResultFromTFunc);
+
+        AssertDefaultFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Task.Right.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTestsTaskRight : BindTryTestsBase
+{
+    [Test]
+    public async Task BindTryAsyncTaskRightReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = await Result.Fail(ErrorMessage).BindTryAsync(TaskOkResultFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskRightSelectsNewTypedResult()
+    {
+        var output = await Result.Ok().BindTryAsync(TaskOkResultTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskRightConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await Result.Ok().BindTryAsync(ThrowTaskResultFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskRightTSelectsNewResult()
+    {
+        var output = await Result.Ok(TValue.Value).BindTryAsync(TaskOkResultFromTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskRightTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok(TValue.Value).BindTryAsync(ThrowTaskResultTFromTFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.Task.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTestsTask : BindTryTestsBase
+{
+    [Test]
+    public async Task BindTryAsyncTaskReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = await TaskFailResultAsync().BindTryAsync(TaskOkResultFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskSelectsNewTypedResult()
+    {
+        var output = await TaskOkResultAsync().BindTryAsync(TaskOkResultTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await TaskOkResultAsync().BindTryAsync(ThrowTaskResultFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskTSelectsNewTypedResult()
+    {
+        var output = await TaskOkResultTAsync().BindTryAsync(TaskOkResultTFromTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncTaskTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await TaskOkResultTAsync().BindTryAsync(ThrowTaskResultFromTFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.ValueTask.Left.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTestsValueTaskLeft : BindTryTestsBase
+{
+    [Test]
+    public async Task BindTryAsyncValueTaskLeftReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = await ValueTaskFailResultAsync().BindTryAsync(OkResultFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskLeftSelectsNewTypedResult()
+    {
+        var output = await ValueTaskOkResultAsync().BindTryAsync(OkResultTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskLeftConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ValueTaskOkResultAsync().BindTryAsync(ThrowResultFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskLeftTSelectsNewTypedResult()
+    {
+        var output = await ValueTaskOkResultTAsync().BindTryAsync(OkResultTFromTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskLeftTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await ValueTaskOkResultTAsync().BindTryAsync(ThrowResultFromTFunc);
+
+        AssertDefaultFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.ValueTask.Right.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTestsValueTaskRight : BindTryTestsBase
+{
+    [Test]
+    public async Task BindTryAsyncValueTaskRightReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = await Result.Fail(ErrorMessage).BindTryAsync(ValueTaskOkResultFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskRightSelectsNewTypedResult()
+    {
+        var output = await Result.Ok().BindTryAsync(ValueTaskOkResultTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskRightConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await Result.Ok().BindTryAsync(ThrowValueTaskResultFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskRightTSelectsNewResult()
+    {
+        var output = await Result.Ok(TValue.Value).BindTryAsync(ValueTaskOkResultFromTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskRightTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await Result.Ok(TValue.Value).BindTryAsync(ThrowValueTaskResultTFromTFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.ValueTask.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTestsValueTask : BindTryTestsBase
+{
+    [Test]
+    public async Task BindTryAsyncValueTaskReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = await ValueTaskFailResultAsync().BindTryAsync(ValueTaskOkResultFuncAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskSelectsNewTypedResult()
+    {
+        var output = await ValueTaskOkResultAsync().BindTryAsync(ValueTaskOkResultTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskConvertsExceptionToFailureWithCustomError()
+    {
+        var output = await ValueTaskOkResultAsync().BindTryAsync(ThrowValueTaskResultFuncAsync, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskTSelectsNewTypedResult()
+    {
+        var output = await ValueTaskOkResultTAsync().BindTryAsync(ValueTaskOkResultTFromTFuncAsync);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public async Task BindTryAsyncValueTaskTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = await ValueTaskOkResultTAsync().BindTryAsync(ThrowValueTaskResultFromTFuncAsync);
+
+        AssertDefaultFailure(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindTryTests.cs
@@ -1,0 +1,116 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindTryTests : BindTryTestsBase
+{
+    [Test]
+    public void BindTryReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail(ErrorMessage).BindTry(OkResultFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public void BindTrySelectsNewResult()
+    {
+        var output = Result.Ok().BindTry(OkResultFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public void BindTryConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok().BindTry(ThrowResultFunc);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public void BindTryResultToResultTSelectsNewResult()
+    {
+        var output = Result.Ok().BindTry(OkResultTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public void BindTryResultToResultTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok().BindTry(ThrowResultTFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public void BindTryTResultToResultReturnsSourceFailureAndDoesNotExecuteFunc()
+    {
+        var output = Result.Fail<TValue>(ErrorMessage).BindTry(OkResultFromTFunc);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public void BindTryTResultToResultSelectsNewResult()
+    {
+        var output = Result.Ok(TValue.Value).BindTry(OkResultFromTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public void BindTryTResultToResultConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok(TValue.Value).BindTry(ThrowResultFromTFunc, CustomErrorHandler);
+
+        AssertCustomFailure(output);
+    }
+
+    [Test]
+    public void BindTryTResultToResultTSelectsNewResult()
+    {
+        var output = Result.Ok(TValue.Value).BindTry(OkResultTFromTFunc);
+
+        AssertSuccess(output);
+    }
+
+    [Test]
+    public void BindTryTResultToResultTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok(TValue.Value).BindTry(ThrowResultTFromTFunc);
+
+        AssertDefaultFailure(output);
+    }
+
+    [Test]
+    public void BindTryThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok().BindTry((Func<Result>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void BindTryResultToResultTThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok().BindTry((Func<Result<TValueMapped>>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void BindTryTResultToResultThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).BindTry((Func<TValue, Result>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void BindTryTResultToResultTThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).BindTry((Func<TValue, Result<TValueMapped>>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Implement issue #40 by adding BindTry support aligned with CSharpFunctionalExtensions and current repository conventions.

## Why
BindTry is missing in this repository. It is the Bind equivalent that converts thrown exceptions into failed results instead of letting them escape.

## How to test
- Run dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln
- Expected result: all tests pass for 
et8, 
et9, and 
et10

## Risks
- Adds a broad overload surface, but signatures follow the existing Bind, MapTry, and async left/right/wrapper patterns used in the repository.

Closes #40