### PR TITLE
feat(bindoptional): add nullable optional bind overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,31 @@ var output4 = await GetNumberAsync()
 </details>
 
 <details>
+<summary><strong>BindOptional</strong></summary>
+
+Conditionally executes bind logic for nullable result values.
+If the source result is failed, the failure is preserved.
+If the source result is successful and the value is `null`, the delegate is skipped and a successful `null` result is returned.
+
+```csharp
+var output = Result.Ok<string?>("alice")
+    .BindOptional(name => Result.Ok<string?>($"{name}@example.com"));
+
+var output2 = Result.Ok<string?>(null)
+    .BindOptional(name => Result.Ok<string?>($"{name}@example.com"));
+
+public Task<Result<int?>> DoubleAsync(int value)
+...
+var output3 = await Result.Ok<int?>(21)
+    .BindOptionalAsync(DoubleAsync);
+
+var output4 = await GetNullableNameAsync()
+    .BindOptionalAsync(name => ValueTask.FromResult(Result.Ok<string?>($"user:{name}")));
+```
+
+</details>
+
+<details>
 <summary><strong>Tap</strong></summary>
 
 Executes an action if the result is successful and return the original result.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.Task.Left.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Task<Result<TValue?>> resultTask,
+        Func<TValue, Result<TValueOut?>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindOptional(func);
+    }
+
+    public static async Task<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Task<Result<TValue?>> resultTask,
+        Func<TValue, Result<TValueOut?>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindOptional(func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.Task.Right.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static Task<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Result<TValue?> result,
+        Func<TValue, Task<Result<TValueOut?>>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Task.FromResult(Result.Fail<TValueOut?>(result.Errors));
+        }
+
+        return result.Value is null
+            ? Task.FromResult(Result.Ok<TValueOut?>(default))
+            : func(result.Value);
+    }
+
+    public static Task<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Result<TValue?> result,
+        Func<TValue, Task<Result<TValueOut?>>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Task.FromResult(Result.Fail<TValueOut?>(result.Errors));
+        }
+
+        return result.Value.HasValue
+            ? func(result.Value.Value)
+            : Task.FromResult(Result.Ok<TValueOut?>(default));
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.Task.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async Task<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Task<Result<TValue?>> resultTask,
+        Func<TValue, Task<Result<TValueOut?>>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindOptionalAsync(func).ConfigureAwait(false);
+    }
+
+    public static async Task<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Task<Result<TValue?>> resultTask,
+        Func<TValue, Task<Result<TValueOut?>>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindOptionalAsync(func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.ValueTask.Left.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue?>> resultTask,
+        Func<TValue, Result<TValueOut?>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindOptional(func);
+    }
+
+    public static async ValueTask<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue?>> resultTask,
+        Func<TValue, Result<TValueOut?>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.BindOptional(func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.ValueTask.Right.cs
@@ -1,0 +1,38 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static ValueTask<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Result<TValue?> result,
+        Func<TValue, ValueTask<Result<TValueOut?>>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return ValueTask.FromResult(Result.Fail<TValueOut?>(result.Errors));
+        }
+
+        return result.Value is null
+            ? ValueTask.FromResult(Result.Ok<TValueOut?>(default))
+            : func(result.Value);
+    }
+
+    public static ValueTask<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this Result<TValue?> result,
+        Func<TValue, ValueTask<Result<TValueOut?>>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return ValueTask.FromResult(Result.Fail<TValueOut?>(result.Errors));
+        }
+
+        return result.Value.HasValue
+            ? func(result.Value.Value)
+            : ValueTask.FromResult(Result.Ok<TValueOut?>(default));
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.ValueTask.cs
@@ -1,0 +1,26 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    public static async ValueTask<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue?>> resultTask,
+        Func<TValue, ValueTask<Result<TValueOut?>>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindOptionalAsync(func).ConfigureAwait(false);
+    }
+
+    public static async ValueTask<Result<TValueOut?>> BindOptionalAsync<TValue, TValueOut>(
+        this ValueTask<Result<TValue?>> resultTask,
+        Func<TValue, ValueTask<Result<TValueOut?>>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.BindOptionalAsync(func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/BindOptional.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Binds a successful nullable reference result only when the value is non-null.
+    /// </summary>
+    public static Result<TValueOut?> BindOptional<TValue, TValueOut>(
+        this Result<TValue?> result,
+        Func<TValue, Result<TValueOut?>> func)
+        where TValue : class
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValueOut?>(result.Errors);
+        }
+
+        return result.Value is null
+            ? Result.Ok<TValueOut?>(default)
+            : func(result.Value);
+    }
+
+    /// <summary>
+    /// Binds a successful nullable struct result only when the value is present.
+    /// </summary>
+    public static Result<TValueOut?> BindOptional<TValue, TValueOut>(
+        this Result<TValue?> result,
+        Func<TValue, Result<TValueOut?>> func)
+        where TValue : struct
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return Result.Fail<TValueOut?>(result.Errors);
+        }
+
+        return result.Value.HasValue
+            ? func(result.Value.Value)
+            : Result.Ok<TValueOut?>(default);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Base.cs
@@ -1,0 +1,88 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class BindOptionalTestsBase : TestBase
+{
+    protected const string SourceReferenceValue = "source";
+    protected const string MappedReferenceValue = "mapped";
+    protected const int SourceStructValue = 42;
+    protected const int MappedStructValue = 84;
+
+    protected Result<string?> BindReference(string value)
+    {
+        FuncExecuted = true;
+        value.Should().Be(SourceReferenceValue);
+        return Result.Ok<string?>(MappedReferenceValue);
+    }
+
+    protected Result<int?> BindStruct(int value)
+    {
+        FuncExecuted = true;
+        value.Should().Be(SourceStructValue);
+        return Result.Ok<int?>(MappedStructValue);
+    }
+
+    protected Task<Result<string?>> TaskBindReferenceAsync(string value)
+    {
+        FuncExecuted = true;
+        value.Should().Be(SourceReferenceValue);
+        return Task.FromResult(Result.Ok<string?>(MappedReferenceValue));
+    }
+
+    protected Task<Result<int?>> TaskBindStructAsync(int value)
+    {
+        FuncExecuted = true;
+        value.Should().Be(SourceStructValue);
+        return Task.FromResult(Result.Ok<int?>(MappedStructValue));
+    }
+
+    protected ValueTask<Result<string?>> ValueTaskBindReferenceAsync(string value)
+    {
+        FuncExecuted = true;
+        value.Should().Be(SourceReferenceValue);
+        return ValueTask.FromResult(Result.Ok<string?>(MappedReferenceValue));
+    }
+
+    protected ValueTask<Result<int?>> ValueTaskBindStructAsync(int value)
+    {
+        FuncExecuted = true;
+        value.Should().Be(SourceStructValue);
+        return ValueTask.FromResult(Result.Ok<int?>(MappedStructValue));
+    }
+
+    protected void AssertSourceFailure<TValue>(Result<TValue?> output)
+    {
+        output.IsFailed.Should().BeTrue();
+        output.Errors.Should().ContainSingle(error => error.Message == ErrorMessage);
+        FuncExecuted.Should().BeFalse();
+    }
+
+    protected void AssertSkippedReference(Result<string?> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeNull();
+        FuncExecuted.Should().BeFalse();
+    }
+
+    protected void AssertSkippedStruct(Result<int?> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().BeNull();
+        FuncExecuted.Should().BeFalse();
+    }
+
+    protected void AssertMappedReference(Result<string?> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(MappedReferenceValue);
+        FuncExecuted.Should().BeTrue();
+    }
+
+    protected void AssertMappedStruct(Result<int?> output)
+    {
+        output.IsSuccess.Should().BeTrue();
+        output.Value.Should().Be(MappedStructValue);
+        FuncExecuted.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Task.Left.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTestsTaskLeft : BindOptionalTestsBase
+{
+    [Test]
+    public async Task BindOptionalAsyncTaskLeftReferenceReturnsNullWhenSourceValueIsNull()
+    {
+        var output = await Task.FromResult(Result.Ok<string?>(null)).BindOptionalAsync(BindReference);
+
+        AssertSkippedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncTaskLeftReferenceMapsValueWhenSourceValueIsNotNull()
+    {
+        var output = await Task.FromResult(Result.Ok<string?>(SourceReferenceValue)).BindOptionalAsync(BindReference);
+
+        AssertMappedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncTaskLeftStructMapsValueWhenSourceValueIsPresent()
+    {
+        var output = await Task.FromResult(Result.Ok<int?>(SourceStructValue)).BindOptionalAsync(BindStruct);
+
+        AssertMappedStruct(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Task.Right.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTestsTaskRight : BindOptionalTestsBase
+{
+    [Test]
+    public async Task BindOptionalAsyncTaskRightReferenceReturnsSourceFailureAndSkipsFunc()
+    {
+        var output = await Result.Fail<string?>(ErrorMessage).BindOptionalAsync(TaskBindReferenceAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncTaskRightReferenceReturnsNullWhenSourceValueIsNull()
+    {
+        var output = await Result.Ok<string?>(null).BindOptionalAsync(TaskBindReferenceAsync);
+
+        AssertSkippedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncTaskRightStructMapsValueWhenSourceValueIsPresent()
+    {
+        var output = await Result.Ok<int?>(SourceStructValue).BindOptionalAsync(TaskBindStructAsync);
+
+        AssertMappedStruct(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.Task.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTestsTask : BindOptionalTestsBase
+{
+    [Test]
+    public async Task BindOptionalAsyncTaskReferenceReturnsSourceFailureAndSkipsFunc()
+    {
+        var output = await Task.FromResult(Result.Fail<string?>(ErrorMessage)).BindOptionalAsync(TaskBindReferenceAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncTaskReferenceMapsValueWhenSourceValueIsNotNull()
+    {
+        var output = await Task.FromResult(Result.Ok<string?>(SourceReferenceValue)).BindOptionalAsync(TaskBindReferenceAsync);
+
+        AssertMappedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncTaskStructReturnsNullWhenSourceValueIsNull()
+    {
+        var output = await Task.FromResult(Result.Ok<int?>(null)).BindOptionalAsync(TaskBindStructAsync);
+
+        AssertSkippedStruct(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.ValueTask.Left.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTestsValueTaskLeft : BindOptionalTestsBase
+{
+    [Test]
+    public async Task BindOptionalAsyncValueTaskLeftReferenceReturnsNullWhenSourceValueIsNull()
+    {
+        var output = await ValueTask.FromResult(Result.Ok<string?>(null)).BindOptionalAsync(BindReference);
+
+        AssertSkippedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncValueTaskLeftReferenceMapsValueWhenSourceValueIsNotNull()
+    {
+        var output = await ValueTask.FromResult(Result.Ok<string?>(SourceReferenceValue)).BindOptionalAsync(BindReference);
+
+        AssertMappedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncValueTaskLeftStructMapsValueWhenSourceValueIsPresent()
+    {
+        var output = await ValueTask.FromResult(Result.Ok<int?>(SourceStructValue)).BindOptionalAsync(BindStruct);
+
+        AssertMappedStruct(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.ValueTask.Right.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTestsValueTaskRight : BindOptionalTestsBase
+{
+    [Test]
+    public async Task BindOptionalAsyncValueTaskRightReferenceReturnsSourceFailureAndSkipsFunc()
+    {
+        var output = await Result.Fail<string?>(ErrorMessage).BindOptionalAsync(ValueTaskBindReferenceAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncValueTaskRightReferenceReturnsNullWhenSourceValueIsNull()
+    {
+        var output = await Result.Ok<string?>(null).BindOptionalAsync(ValueTaskBindReferenceAsync);
+
+        AssertSkippedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncValueTaskRightStructMapsValueWhenSourceValueIsPresent()
+    {
+        var output = await Result.Ok<int?>(SourceStructValue).BindOptionalAsync(ValueTaskBindStructAsync);
+
+        AssertMappedStruct(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.ValueTask.cs
@@ -1,0 +1,28 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTestsValueTask : BindOptionalTestsBase
+{
+    [Test]
+    public async Task BindOptionalAsyncValueTaskReferenceReturnsSourceFailureAndSkipsFunc()
+    {
+        var output = await ValueTask.FromResult(Result.Fail<string?>(ErrorMessage)).BindOptionalAsync(ValueTaskBindReferenceAsync);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncValueTaskReferenceMapsValueWhenSourceValueIsNotNull()
+    {
+        var output = await ValueTask.FromResult(Result.Ok<string?>(SourceReferenceValue)).BindOptionalAsync(ValueTaskBindReferenceAsync);
+
+        AssertMappedReference(output);
+    }
+
+    [Test]
+    public async Task BindOptionalAsyncValueTaskStructReturnsNullWhenSourceValueIsNull()
+    {
+        var output = await ValueTask.FromResult(Result.Ok<int?>(null)).BindOptionalAsync(ValueTaskBindStructAsync);
+
+        AssertSkippedStruct(output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/BindOptionalTests.cs
@@ -1,0 +1,60 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class BindOptionalTests : BindOptionalTestsBase
+{
+    [Test]
+    public void BindOptionalReferenceReturnsSourceFailureAndSkipsFunc()
+    {
+        var output = Result.Fail<string?>(ErrorMessage).BindOptional(BindReference);
+
+        AssertSourceFailure(output);
+    }
+
+    [Test]
+    public void BindOptionalReferenceReturnsNullWhenSourceValueIsNull()
+    {
+        var output = Result.Ok<string?>(null).BindOptional(BindReference);
+
+        AssertSkippedReference(output);
+    }
+
+    [Test]
+    public void BindOptionalReferenceMapsValueWhenSourceValueIsNotNull()
+    {
+        var output = Result.Ok<string?>(SourceReferenceValue).BindOptional(BindReference);
+
+        AssertMappedReference(output);
+    }
+
+    [Test]
+    public void BindOptionalStructReturnsNullWhenSourceValueIsNull()
+    {
+        var output = Result.Ok<int?>(null).BindOptional(BindStruct);
+
+        AssertSkippedStruct(output);
+    }
+
+    [Test]
+    public void BindOptionalStructMapsValueWhenSourceValueIsPresent()
+    {
+        var output = Result.Ok<int?>(SourceStructValue).BindOptional(BindStruct);
+
+        AssertMappedStruct(output);
+    }
+
+    [Test]
+    public void BindOptionalReferenceThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok<string?>(SourceReferenceValue).BindOptional((Func<string, Result<string?>>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void BindOptionalStructThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Ok<int?>(SourceStructValue).BindOptional((Func<int, Result<int?>>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
Implement issue #39 by adding nullable-based BindOptional support aligned with the direction agreed on in the issue discussion.

## Why
FluentResults does not have a native Maybe / Optional abstraction, so this implementation uses nullable payloads as the optional carrier for the extension library.

## How to test
- Run dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln
- Expected result: all tests pass for 
et8, 
et9, and 
et10

## Risks
- This is intentionally nullable-based rather than a strict Maybe-based port from CSharpFunctionalExtensions.
- 
ull is treated as the absent optional value.

Closes #39