### PR TITLE
feat(tapif): add TapIf extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,30 @@ await GetResultAsync().TapAsync(OnActionValueTaskAsync);
 </details>
 
 <details>
+<summary><strong>TapIf</strong></summary>
+
+Conditionally executes `Tap` logic.
+If the condition or predicate is not satisfied, it returns the original result unchanged.
+
+```csharp
+var output = Result.Ok(10)
+    .TapIf(true, () => Log("ok"));
+
+var output2 = Result.Ok(10)
+    .TapIf(value => value > 5, value => Audit(value));
+
+public Task NotifyAsync(int value)
+...
+var output3 = await Result.Ok(10)
+    .TapIfAsync(value => value > 5, NotifyAsync);
+
+var output4 = await GetNumberAsync()
+    .TapIfAsync(true, value => ValueTask.CompletedTask);
+```
+
+</details>
+
+<details>
 <summary><strong>Match</strong></summary>
 
 Matches a Result to either a success or failure action.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.Task.Left.cs
@@ -1,0 +1,101 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfAsync(this Task<Result> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Action<TValue> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfAsync(this Task<Result> resultTask, Func<bool> predicate, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(predicate, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(predicate, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action<TValue> action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(predicate, action);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.Task.Right.cs
@@ -1,0 +1,103 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result> TapIfAsync(this Result result, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, bool condition, Func<TValue, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result> TapIfAsync(this Result result, Func<bool> predicate, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate()
+            ? result.TapAsync(func)
+            : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.TapAsync(func)
+            : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.TapAsync(func)
+            : Task.FromResult(result);
+    }
+
+    // ValueTask-based overloads for Result are in TapIf.ValueTask.Right.cs
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.Task.cs
@@ -1,0 +1,214 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfAsync(this Task<Result> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfAsync(this Task<Result> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (condition && result.IsSuccess)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (condition && result.IsSuccess)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<TValue, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<TValue, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfAsync(this Task<Result> resultTask, Func<bool> predicate, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfAsync(this Task<Result> resultTask, Func<bool> predicate, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess && predicate())
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsSuccess && predicate(result.Value))
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.ValueTask.Left.cs
@@ -1,0 +1,101 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfAsync(this ValueTask<Result> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Action<TValue> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(predicate, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(predicate, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action<TValue> action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIf(predicate, action);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.ValueTask.Right.cs
@@ -1,0 +1,101 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static ValueTask<Result> TapIfAsync(this Result result, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static ValueTask<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static ValueTask<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, bool condition, Func<TValue, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static ValueTask<Result> TapIfAsync(this Result result, Func<bool> predicate, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate()
+            ? result.TapAsync(func)
+            : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static ValueTask<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.TapAsync(func)
+            : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static ValueTask<Result<TValue>> TapIfAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.TapAsync(func)
+            : ValueTask.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.ValueTask.cs
@@ -1,0 +1,198 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfAsync(this ValueTask<Result> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfAsync(this ValueTask<Result> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<TValue, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<TValue, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfAsync(predicate, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIf.cs
@@ -1,0 +1,101 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result TapIf(this Result result, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.Tap(action) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapIf<TValue>(this Result<TValue> result, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.Tap(action) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapIf<TValue>(this Result<TValue> result, bool condition, Action<TValue> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.Tap(action) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result TapIf(this Result result, Func<bool> predicate, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        return result.IsSuccess && predicate()
+            ? result.Tap(action)
+            : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapIf<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.Tap(action)
+            : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the result is successful.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapIf<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Action<TValue> action)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        return result.IsSuccess && predicate(result.Value)
+            ? result.Tap(action)
+            : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Base.cs
@@ -1,0 +1,87 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class TapIfTestsBase : TestBase
+{
+    protected bool ActionExecuted { get; private set; }
+    protected bool PredicateExecuted { get; private set; }
+
+    protected void ActionEmpty() => ActionExecuted = true;
+
+    protected void ActionT(TValue value) => ActionExecuted = true;
+
+    protected Task TaskActionEmptyAsync()
+    {
+        ActionExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    protected Task TaskActionTAsync(TValue value)
+    {
+        ActionExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskActionEmptyAsync()
+    {
+        ActionExecuted = true;
+        return ValueTask.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskActionTAsync(TValue value)
+    {
+        ActionExecuted = true;
+        return ValueTask.CompletedTask;
+    }
+
+    protected bool TruePredicate()
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate()
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected bool TruePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate(TValue value)
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected void AssertSkipped(Result expected, Result output, bool predicateExecuted)
+    {
+        PredicateExecuted.Should().Be(predicateExecuted);
+        ActionExecuted.Should().BeFalse();
+        output.Should().BeSameAs(expected);
+    }
+
+    protected void AssertSkipped(Result<TValue> expected, Result<TValue> output, bool predicateExecuted)
+    {
+        PredicateExecuted.Should().Be(predicateExecuted);
+        ActionExecuted.Should().BeFalse();
+        output.Should().BeSameAs(expected);
+    }
+
+    protected void AssertExecuted(Result output, bool shouldExecute, bool isSuccess)
+    {
+        ActionExecuted.Should().Be(shouldExecute);
+        output.IsSuccess.Should().Be(isSuccess);
+    }
+
+    protected void AssertExecuted(Result<TValue> output, bool shouldExecute, bool isSuccess)
+    {
+        ActionExecuted.Should().Be(shouldExecute);
+        output.IsSuccess.Should().Be(isSuccess);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Task.Left.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTestsTaskLeft : TapIfTestsBase
+{
+    [Test]
+    public async Task TapIfTaskLeftConditionTrueExecutesAction()
+    {
+        var result = Task.FromResult(Result.Ok());
+
+        var output = await result.TapIfAsync(true, ActionEmpty);
+
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfTaskLeftPredicateFalseSkipsAction()
+    {
+        var result = Task.FromResult(Result.Ok());
+
+        var output = await result.TapIfAsync(FalsePredicate, ActionEmpty);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeFalse();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Task.Right.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTestsTaskRight : TapIfTestsBase
+{
+    [Test]
+    public async Task TapIfTaskRightConditionFalseSkipsAction()
+    {
+        var result = Result.Ok();
+
+        var output = await result.TapIfAsync(false, TaskActionEmptyAsync);
+
+        ActionExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task TapIfTaskRightPredicateTrueExecutesAction()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.TapIfAsync(TruePredicate, TaskActionTAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.Task.cs
@@ -1,0 +1,61 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTestsTask : TapIfTestsBase
+{
+    [Test]
+    public async Task TapIfTaskConditionFalseSkipsAction()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask();
+
+        var output = await result.TapIfAsync(false, TaskActionEmptyAsync);
+
+        ActionExecuted.Should().BeFalse();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfTaskConditionTrueExecutesAction()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask();
+
+        var output = await result.TapIfAsync(true, TaskActionEmptyAsync);
+
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfTaskPredicateFalseSkipsAction()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask();
+
+        var output = await result.TapIfAsync(FalsePredicate, TaskActionEmptyAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeFalse();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfTaskPredicateOnFailedSourceSkipsPredicateAndAction()
+    {
+        var result = ResultExtensions.OkIfAsync(false, ErrorMessage).AsTask();
+
+        var output = await result.TapIfAsync(TruePredicate, TaskActionEmptyAsync);
+
+        PredicateExecuted.Should().BeFalse();
+        ActionExecuted.Should().BeFalse();
+        output.IsFailed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfTaskConditionTrueExecutesActionT()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage, TValue.Value).AsTask();
+
+        var output = await result.TapIfAsync(true, TaskActionTAsync);
+
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.ValueTask.Left.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTestsValueTaskLeft : TapIfTestsBase
+{
+    [Test]
+    public async Task TapIfValueTaskLeftConditionTrueExecutesAction()
+    {
+        var result = new ValueTask<Result>(Result.Ok());
+
+        var output = await result.TapIfAsync(true, ActionEmpty);
+
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfValueTaskLeftPredicateFalseSkipsAction()
+    {
+        var result = new ValueTask<Result>(Result.Ok());
+
+        var output = await result.TapIfAsync(FalsePredicate, ActionEmpty);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeFalse();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.ValueTask.Right.cs
@@ -1,0 +1,27 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTestsValueTaskRight : TapIfTestsBase
+{
+    [Test]
+    public async Task TapIfValueTaskRightConditionFalseSkipsAction()
+    {
+        var result = Result.Ok();
+
+        var output = await result.TapIfAsync(false, ValueTaskActionEmptyAsync);
+
+        ActionExecuted.Should().BeFalse();
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public async Task TapIfValueTaskRightPredicateTrueExecutesAction()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = await result.TapIfAsync(TruePredicate, ValueTaskActionTAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.ValueTask.cs
@@ -1,0 +1,61 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTestsValueTask : TapIfTestsBase
+{
+    [Test]
+    public async Task TapIfValueTaskConditionFalseSkipsAction()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage);
+
+        var output = await result.TapIfAsync(false, ValueTaskActionEmptyAsync);
+
+        ActionExecuted.Should().BeFalse();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfValueTaskConditionTrueExecutesAction()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage);
+
+        var output = await result.TapIfAsync(true, ValueTaskActionEmptyAsync);
+
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfValueTaskPredicateFalseSkipsAction()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage);
+
+        var output = await result.TapIfAsync(FalsePredicate, TaskActionEmptyAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeFalse();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfValueTaskPredicateOnFailedSourceSkipsPredicateAndAction()
+    {
+        var result = ResultExtensions.OkIfAsync(false, ErrorMessage);
+
+        var output = await result.TapIfAsync(TruePredicate, ValueTaskActionEmptyAsync);
+
+        PredicateExecuted.Should().BeFalse();
+        ActionExecuted.Should().BeFalse();
+        output.IsFailed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TapIfValueTaskConditionTrueExecutesActionT()
+    {
+        var result = ResultExtensions.OkIfAsync(true, ErrorMessage, TValue.Value);
+
+        var output = await result.TapIfAsync(true, ValueTaskActionTAsync);
+
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTests.cs
@@ -1,0 +1,85 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTests : TapIfTestsBase
+{
+    [Test]
+    public void TapIfConditionFalseReturnsOriginalResultAndSkipsAction()
+    {
+        var result = Result.Ok();
+
+        var output = result.TapIf(false, ActionEmpty);
+
+        AssertSkipped(result, output, predicateExecuted: false);
+    }
+
+    [Test]
+    public void TapIfConditionTrueExecutesActionOnSuccess()
+    {
+        var output = Result.Ok().TapIf(true, ActionEmpty);
+
+        AssertExecuted(output, shouldExecute: true, isSuccess: true);
+    }
+
+    [Test]
+    public void TapIfConditionTrueOnFailedSourceSkipsAction()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        var output = result.TapIf(true, ActionEmpty);
+
+        AssertExecuted(output, shouldExecute: false, isSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+
+    [Test]
+    public void TapIfPredicateOnFailedSourceSkipsPredicateAndAction()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        var output = result.TapIf(TruePredicate, ActionEmpty);
+
+        PredicateExecuted.Should().BeFalse();
+        ActionExecuted.Should().BeFalse();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+
+    [Test]
+    public void TapIfConditionTrueExecutesActionTOnSuccess()
+    {
+        var output = Result.Ok(TValue.Value).TapIf(true, ActionT);
+
+        AssertExecuted(output, shouldExecute: true, isSuccess: true);
+    }
+
+    [Test]
+    public void TapIfPredicateFalseReturnsOriginalResultAndSkipsAction()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.TapIf(FalsePredicate, ActionEmpty);
+
+        AssertSkipped(result, output, predicateExecuted: true);
+    }
+
+    [Test]
+    public void TapIfPredicateTrueExecutesActionTOnSuccess()
+    {
+        var output = Result.Ok(TValue.Value).TapIf(TruePredicate, ActionT);
+
+        PredicateExecuted.Should().BeTrue();
+        ActionExecuted.Should().BeTrue();
+        output.IsSuccess.Should().BeTrue();
+    }
+
+    [Test]
+    public void TapIfPredicateOnFailedResultTSkipsPredicateAndAction()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = result.TapIf(TruePredicate, ActionT);
+
+        PredicateExecuted.Should().BeFalse();
+        ActionExecuted.Should().BeFalse();
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+}


### PR DESCRIPTION
## What
- add TapIf sync/async overloads for Result types
- add TapIf test coverage and docs
- ensure XML docs for public APIs

## Why
- provide TapIf support aligned with CSharpFunctionalExtensions (issue #67)

## How to test
- dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln

## Risks
- low; additive API with tests

Closes #67