### PR TITLE
feat(tapiftry): add TapIfTry extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,30 @@ var output4 = await GetNumberAsync()
 </details>
 
 <details>
+<summary><strong>TapIfTry</strong></summary>
+
+Conditionally executes `Tap` logic and converts thrown exceptions into failures.
+If the condition or predicate is not satisfied, it returns the original result unchanged.
+
+```csharp
+var output = Result.Ok(10)
+    .TapIfTry(true, () => Log("ok"));
+
+var output2 = Result.Ok(10)
+    .TapIfTry(value => value > 5, value => Audit(value));
+
+public Task NotifyAsync(int value)
+...
+var output3 = await Result.Ok(10)
+    .TapIfTryAsync(value => value > 5, NotifyAsync);
+
+var output4 = await GetNumberAsync()
+    .TapIfTryAsync(true, value => ValueTask.CompletedTask);
+```
+
+</details>
+
+<details>
 <summary><strong>Match</strong></summary>
 
 Matches a Result to either a success or failure action.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.Task.Left.cs
@@ -1,0 +1,107 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Task<Result> resultTask, bool condition, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(condition, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(condition, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(condition, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Task<Result> resultTask, Func<bool> predicate, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(predicate, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(predicate, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(predicate, action, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.Task.Right.cs
@@ -1,0 +1,151 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Result result, bool condition, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, bool condition, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, bool condition, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Result result, Func<bool> predicate, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<Task>)(async () =>
+        {
+            if (predicate())
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<Task>)(async () =>
+        {
+            if (predicate(result.Value))
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => predicate(result.Value) ? func(result.Value) : Task.CompletedTask, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.Task.cs
@@ -1,0 +1,260 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Task<Result> resultTask, bool condition, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(condition, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Task<Result> resultTask, bool condition, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(condition, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(condition, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Task<Result> resultTask, Func<bool> predicate, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(predicate, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapIfTryAsync(this Task<Result> resultTask, Func<bool> predicate, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<Task>)(async () =>
+        {
+            if (predicate())
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(predicate, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<Task>)(async () =>
+        {
+            if (predicate(result.Value))
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(predicate, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapIfTryAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => predicate(result.Value) ? func(result.Value) : ValueTask.CompletedTask, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.ValueTask.Left.cs
@@ -1,0 +1,107 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this ValueTask<Result> resultTask, bool condition, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(condition, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(condition, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(condition, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(predicate, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(predicate, action, errorHandler);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapIfTry(predicate, action, errorHandler);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.ValueTask.Right.cs
@@ -1,0 +1,151 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this Result result, bool condition, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, bool condition, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, bool condition, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this Result result, Func<bool> predicate, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<ValueTask>)(async () =>
+        {
+            if (predicate())
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<ValueTask>)(async () =>
+        {
+            if (predicate(result.Value))
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => predicate(result.Value) ? func(result.Value) : ValueTask.CompletedTask, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.ValueTask.cs
@@ -1,0 +1,260 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this ValueTask<Result> resultTask, bool condition, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(condition, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this ValueTask<Result> resultTask, bool condition, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(condition, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(func, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(condition, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => func(result.Value), errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(predicate, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapIfTryAsync(this ValueTask<Result> resultTask, Func<bool> predicate, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<Task>)(async () =>
+        {
+            if (predicate())
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(predicate, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync((Func<Task>)(async () =>
+        {
+            if (predicate(result.Value))
+            {
+                await func().ConfigureAwait(false);
+            }
+        }), errorHandler).ConfigureAwait(false);
+
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, ValueTask> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapIfTryAsync(predicate, func, errorHandler).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied predicate evaluates to true and the awaited result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The valuetask producing the result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>A valuetask representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapIfTryAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<TValue, bool> predicate, Func<TValue, Task> func, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = await TryAsync(() => predicate(result.Value) ? func(result.Value) : Task.CompletedTask, errorHandler).ConfigureAwait(false);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapIfTry.cs
@@ -1,0 +1,158 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original result, or a failed result when an exception occurs.</returns>
+    public static Result TapIfTry(this Result result, bool condition, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = Try(action, errorHandler);
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original result, or a failed result when an exception occurs.</returns>
+    public static Result<TValue> TapIfTry<TValue>(this Result<TValue> result, bool condition, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = Try(action, errorHandler);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original result, or a failed result when an exception occurs.</returns>
+    public static Result<TValue> TapIfTry<TValue>(this Result<TValue> result, bool condition, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed || !condition)
+        {
+            return result;
+        }
+
+        var attempt = Try(() => action(result.Value), errorHandler);
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original result, or a failed result when an exception occurs.</returns>
+    public static Result TapIfTry(this Result result, Func<bool> predicate, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = Try(() =>
+        {
+            if (predicate())
+            {
+                action();
+            }
+        }, errorHandler);
+
+        return attempt.IsFailed ? attempt : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original result, or a failed result when an exception occurs.</returns>
+    public static Result<TValue> TapIfTry<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Action action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = Try(() =>
+        {
+            if (predicate(result.Value))
+            {
+                action();
+            }
+        }, errorHandler);
+
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied predicate evaluates to true and the result is successful, converting exceptions to failures.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="predicate">Predicate that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="errorHandler">Optional exception-to-error-message mapper. Defaults to exception message.</param>
+    /// <returns>The original result, or a failed result when an exception occurs.</returns>
+    public static Result<TValue> TapIfTry<TValue>(this Result<TValue> result, Func<TValue, bool> predicate, Action<TValue> action, Func<Exception, string>? errorHandler = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            return result;
+        }
+
+        var attempt = Try(() =>
+        {
+            if (predicate(result.Value))
+            {
+                action(result.Value);
+            }
+        }, errorHandler);
+
+        return attempt.IsFailed ? Result.Fail<TValue>(attempt.Errors) : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Base.cs
@@ -1,0 +1,113 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class TapIfTryTestsBase : TestBase
+{
+    protected const string TryExceptionMessage = "TapIfTry Exception Message";
+    protected const string CustomErrorMessage = "Custom TapIfTry Error Message";
+
+    private bool actionExecuted;
+    protected bool PredicateExecuted { get; private set; }
+
+    protected void ActionEmpty() => actionExecuted = true;
+    protected void ActionWithValue(TValue _) => actionExecuted = true;
+
+    protected void ThrowAction()
+    {
+        actionExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected void ThrowActionWithValue(TValue _)
+    {
+        actionExecuted = true;
+        throw new InvalidOperationException(TryExceptionMessage);
+    }
+
+    protected Task TaskActionEmptyAsync()
+    {
+        actionExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    protected Task TaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return Task.CompletedTask;
+    }
+
+    protected Task ThrowTaskActionAsync()
+    {
+        actionExecuted = true;
+        return Task.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected Task ThrowTaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return Task.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask ValueTaskActionEmptyAsync()
+    {
+        actionExecuted = true;
+        return ValueTask.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return ValueTask.CompletedTask;
+    }
+
+    protected ValueTask ThrowValueTaskActionAsync()
+    {
+        actionExecuted = true;
+        return ValueTask.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected ValueTask ThrowValueTaskActionWithValueAsync(TValue _)
+    {
+        actionExecuted = true;
+        return ValueTask.FromException(new InvalidOperationException(TryExceptionMessage));
+    }
+
+    protected bool TruePredicate()
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate()
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected bool TruePredicate(TValue _)
+    {
+        PredicateExecuted = true;
+        return true;
+    }
+
+    protected bool FalsePredicate(TValue _)
+    {
+        PredicateExecuted = true;
+        return false;
+    }
+
+    protected static string CustomErrorHandler(Exception _) => CustomErrorMessage;
+
+    protected void AssertState(Result output, bool expectedActionExecuted, bool expectedSuccess)
+    {
+        actionExecuted.Should().Be(expectedActionExecuted);
+        output.IsSuccess.Should().Be(expectedSuccess);
+    }
+
+    protected void AssertState(Result<TValue> output, bool expectedActionExecuted, bool expectedSuccess)
+    {
+        actionExecuted.Should().Be(expectedActionExecuted);
+        output.IsSuccess.Should().Be(expectedSuccess);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Task.Left.cs
@@ -1,0 +1,25 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTestsTaskLeft : TapIfTryTestsBase
+{
+    [Test]
+    public async Task TapIfTryAsyncExecutesActionWhenConditionTrue()
+    {
+        var resultTask = Task.FromResult(Result.Ok());
+
+        var output = await resultTask.TapIfTryAsync(true, ActionEmpty);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncConvertsExceptionToFailureWithCustomError()
+    {
+        var resultTask = Task.FromResult(Result.Ok());
+
+        var output = await resultTask.TapIfTryAsync(true, ThrowAction, CustomErrorHandler);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == CustomErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Task.Right.cs
@@ -1,0 +1,25 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTestsTaskRight : TapIfTryTestsBase
+{
+    [Test]
+    public async Task TapIfTryAsyncExecutesTaskWhenResultIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await result.TapIfTryAsync(true, TaskActionEmptyAsync);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncPredicateFalseSkipsTask()
+    {
+        var result = Result.Ok();
+
+        var output = await result.TapIfTryAsync(FalsePredicate, TaskActionEmptyAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: true);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.Task.cs
@@ -1,0 +1,44 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTestsTask : TapIfTryTestsBase
+{
+    [Test]
+    public async Task TapIfTryAsyncExecutesTaskWhenConditionTrue()
+    {
+        var resultTask = ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask();
+
+        var output = await resultTask.TapIfTryAsync(true, TaskActionEmptyAsync);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncSkipsTaskWhenConditionFalse()
+    {
+        var resultTask = ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask();
+
+        var output = await resultTask.TapIfTryAsync(false, TaskActionEmptyAsync);
+
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncConvertsTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .TapIfTryAsync(true, ThrowTaskActionAsync);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == TryExceptionMessage);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncConvertsTaskExceptionToFailureWithCustomError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage).AsTask()
+            .TapIfTryAsync(true, ThrowTaskActionAsync, CustomErrorHandler);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == CustomErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.ValueTask.Left.cs
@@ -1,0 +1,25 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTestsValueTaskLeft : TapIfTryTestsBase
+{
+    [Test]
+    public async Task TapIfTryAsyncExecutesActionWhenConditionTrue()
+    {
+        var resultTask = new ValueTask<Result>(Result.Ok());
+
+        var output = await resultTask.TapIfTryAsync(true, ActionEmpty);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncConvertsExceptionToFailureWithCustomError()
+    {
+        var resultTask = new ValueTask<Result>(Result.Ok());
+
+        var output = await resultTask.TapIfTryAsync(true, ThrowAction, CustomErrorHandler);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == CustomErrorMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.ValueTask.Right.cs
@@ -1,0 +1,25 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTestsValueTaskRight : TapIfTryTestsBase
+{
+    [Test]
+    public async Task TapIfTryAsyncExecutesValueTaskWhenResultIsSuccessful()
+    {
+        var result = Result.Ok();
+
+        var output = await result.TapIfTryAsync(true, ValueTaskActionEmptyAsync);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncPredicateFalseSkipsValueTask()
+    {
+        var result = Result.Ok();
+
+        var output = await result.TapIfTryAsync(FalsePredicate, ValueTaskActionEmptyAsync);
+
+        PredicateExecuted.Should().BeTrue();
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: true);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.ValueTask.cs
@@ -1,0 +1,34 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTestsValueTask : TapIfTryTestsBase
+{
+    [Test]
+    public async Task TapIfTryAsyncExecutesValueTaskWhenConditionTrue()
+    {
+        var resultTask = ResultExtensions.OkIfAsync(true, ErrorMessage);
+
+        var output = await resultTask.TapIfTryAsync(true, ValueTaskActionEmptyAsync);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncSkipsValueTaskWhenConditionFalse()
+    {
+        var resultTask = ResultExtensions.OkIfAsync(true, ErrorMessage);
+
+        var output = await resultTask.TapIfTryAsync(false, ValueTaskActionEmptyAsync);
+
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: true);
+    }
+
+    [Test]
+    public async Task TapIfTryAsyncConvertsValueTaskExceptionToFailureWithDefaultError()
+    {
+        var output = await ResultExtensions.OkIfAsync(true, ErrorMessage)
+            .TapIfTryAsync(true, ThrowValueTaskActionAsync);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == TryExceptionMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapIfTryTests.cs
@@ -1,0 +1,109 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapIfTryTests : TapIfTryTestsBase
+{
+    [Test]
+    public void TapIfTryConditionFalseReturnsOriginalResultAndSkipsAction()
+    {
+        var result = Result.Ok();
+
+        var output = result.TapIfTry(false, ActionEmpty);
+
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: true);
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public void TapIfTryConditionTrueExecutesActionOnSuccess()
+    {
+        var output = Result.Ok().TapIfTry(true, ActionEmpty);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: true);
+    }
+
+    [Test]
+    public void TapIfTryConditionTrueOnFailedSourceSkipsAction()
+    {
+        var result = Result.Fail(ErrorMessage);
+
+        var output = result.TapIfTry(true, ActionEmpty);
+
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == ErrorMessage);
+    }
+
+    [Test]
+    public void TapIfTryPredicateFalseReturnsOriginalResultAndSkipsAction()
+    {
+        var result = Result.Ok(TValue.Value);
+
+        var output = result.TapIfTry(FalsePredicate, ActionWithValue);
+
+        PredicateExecuted.Should().BeTrue();
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: true);
+        output.Should().BeSameAs(result);
+    }
+
+    [Test]
+    public void TapIfTryPredicateOnFailedSourceSkipsPredicateAndAction()
+    {
+        var result = Result.Fail<TValue>(ErrorMessage);
+
+        var output = result.TapIfTry(TruePredicate, ActionWithValue);
+
+        PredicateExecuted.Should().BeFalse();
+        AssertState(output, expectedActionExecuted: false, expectedSuccess: false);
+    }
+
+    [Test]
+    public void TapIfTryConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok().TapIfTry(true, ThrowAction);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == TryExceptionMessage);
+    }
+
+    [Test]
+    public void TapIfTryConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok().TapIfTry(true, ThrowAction, CustomErrorHandler);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == CustomErrorMessage);
+    }
+
+    [Test]
+    public void TapIfTryTConvertsExceptionToFailureWithDefaultError()
+    {
+        var output = Result.Ok(TValue.Value).TapIfTry(true, ThrowActionWithValue);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == TryExceptionMessage);
+    }
+
+    [Test]
+    public void TapIfTryTConvertsExceptionToFailureWithCustomError()
+    {
+        var output = Result.Ok(TValue.Value).TapIfTry(true, ThrowActionWithValue, CustomErrorHandler);
+
+        AssertState(output, expectedActionExecuted: true, expectedSuccess: false);
+        output.Errors.Should().Contain(error => error.Message == CustomErrorMessage);
+    }
+
+    [Test]
+    public void TapIfTryThrowsWhenActionIsNull()
+    {
+        var action = () => Result.Ok().TapIfTry(true, null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void TapIfTryTThrowsWhenActionIsNull()
+    {
+        var action = () => Result.Ok(TValue.Value).TapIfTry(true, (Action<TValue>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- add TapIfTry sync/async overloads for Result types
- add TapIfTry test coverage and docs
- ensure XML docs for public APIs

## Why
- provide TapIfTry support aligned with CSharpFunctionalExtensions (issue #68)

## How to test
- dotnet test --solution NKZSoft.FluentResults.Extensions.Functional.sln

## Risks
- low; additive API with tests

Closes #68