### PR TITLE
feat(result): add TapError extensions and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,27 @@ await GetResultAsync().TapAsync(OnActionValueTaskAsync);
 </details>
 
 <details>
+<summary><strong>TapError</strong></summary>
+
+Executes an action when the result is failed and returns the original result.
+For FluentResults compatibility with multiple errors, `TapError` also provides per-error overloads.
+
+```csharp
+var output = Result.Fail("Validation failed")
+    .TapError(() => Log("failed"));
+
+var outputWithValue = Result.Fail<int>("Validation failed")
+    .TapError(error => Log(error.Message));
+
+public Task OnErrorAsync(IError error)
+...
+var asyncOutput = await GetResultAsync()
+    .TapErrorAsync(OnErrorAsync);
+```
+
+</details>
+
+<details>
 <summary><strong>TapIf</strong></summary>
 
 Conditionally executes `Tap` logic.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.Task.Left.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action if the result of the task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+
+    /// <summary>
+    /// Executes an action if the result of the task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Task<Result<TValue>> resultTask, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error if the result of the task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error if the result of the task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Task<Result<TValue>> resultTask, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.Task.Right.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a function if the result is failed.
+    /// </summary>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Result result, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Result<TValue> result, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result is failed.
+    /// </summary>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static Task<Result> TapErrorAsync(this Result result, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.InternalTapErrorAsync(error => new ValueTask(func(error))).AsTask();
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static Task<Result<TValue>> TapErrorAsync<TValue>(this Result<TValue> result, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.InternalTapErrorAsync(error => new ValueTask(func(error))).AsTask();
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.Task.cs
@@ -1,0 +1,120 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Task<Result<TValue>> resultTask, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Task<Result<TValue>> resultTask, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result> TapErrorAsync(this Task<Result> resultTask, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Task<Result<TValue>> resultTask, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async Task<Result<TValue>> TapErrorAsync<TValue>(this Task<Result<TValue>> resultTask, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.ValueTask.Left.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action if the result of the task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+
+    /// <summary>
+    /// Executes an action if the result of the task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error if the result of the task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error if the result of the task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapError(action);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.ValueTask.Right.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a function if the result is failed.
+    /// </summary>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this Result result, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function if the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this Result<TValue> result, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        if (result.IsFailed)
+        {
+            await func().ConfigureAwait(false);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result is failed.
+    /// </summary>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static ValueTask<Result> TapErrorAsync(this Result result, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.InternalTapErrorAsync(func);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static ValueTask<Result<TValue>> TapErrorAsync<TValue>(this Result<TValue> result, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return result.InternalTapErrorAsync(func);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.ValueTask.cs
@@ -1,0 +1,120 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result> TapErrorAsync(this ValueTask<Result> resultTask, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a function for each error if the result of a task is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the result.</typeparam>
+    /// <param name="resultTask">The task that produces the result.</param>
+    /// <param name="func">The function to execute for each error if the result is failed.</param>
+    /// <returns>A task representing the asynchronous operation. The task result contains the original result.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorAsync<TValue>(this ValueTask<Result<TValue>> resultTask, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorAsync(func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapError.cs
@@ -1,0 +1,104 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the result is failed.
+    /// </summary>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="action">The action to execute if the result is failed.</param>
+    /// <returns>The original result.</returns>
+    public static Result TapError(this Result result, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            action();
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes an action when the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="action">The action to execute if the result is failed.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapError<TValue>(this Result<TValue> result, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            action();
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the result is failed.
+    /// </summary>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>The original result.</returns>
+    public static Result TapError(this Result result, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            foreach (var error in result.Errors)
+            {
+                action(error);
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value contained in the Result.</typeparam>
+    /// <param name="result">The result to check for failure.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapError<TValue>(this Result<TValue> result, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (result.IsFailed)
+        {
+            foreach (var error in result.Errors)
+            {
+                action(error);
+            }
+        }
+        return result;
+    }
+
+    internal static async ValueTask<Result> InternalTapErrorAsync(this Result result, Func<IError, ValueTask> func)
+    {
+        if (result.IsFailed)
+        {
+            foreach (var error in result.Errors)
+            {
+                await func(error).ConfigureAwait(false);
+            }
+        }
+        return result;
+    }
+
+    internal static async ValueTask<Result<TValue>> InternalTapErrorAsync<TValue>(this Result<TValue> result, Func<IError, ValueTask> func)
+    {
+        if (result.IsFailed)
+        {
+            foreach (var error in result.Errors)
+            {
+                await func(error).ConfigureAwait(false);
+            }
+        }
+        return result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Base.cs
@@ -1,0 +1,98 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class TapErrorTestsBase : TestBase
+{
+    protected const string SecondErrorMessage = "Second Error Message";
+    protected const string SuccessMessage = "Success Message";
+
+    protected int ActionExecutionCount { get; private set; }
+    protected int ErrorActionExecutionCount { get; private set; }
+    protected List<string> CapturedErrors { get; } = [];
+
+    protected static Result FailedResult()
+        => Result.Fail(new Error(ErrorMessage))
+            .WithError(new Error(SecondErrorMessage))
+            .WithSuccess(SuccessMessage);
+
+    protected static Result<TValue> FailedResultT()
+        => Result.Fail<TValue>(new Error(ErrorMessage))
+            .WithError(new Error(SecondErrorMessage))
+            .WithSuccess(SuccessMessage);
+
+    protected static Result SucceededResult()
+        => Result.Ok().WithSuccess(SuccessMessage);
+
+    protected static Result<TValue> SucceededResultT()
+        => Result.Ok(TValue.Value).WithSuccess(SuccessMessage);
+
+    protected void Action()
+        => ActionExecutionCount++;
+
+    protected Task TaskActionAsync()
+    {
+        ActionExecutionCount++;
+        return Task.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskActionAsync()
+    {
+        ActionExecutionCount++;
+        return ValueTask.CompletedTask;
+    }
+
+    protected void ErrorAction(IError error)
+    {
+        ErrorActionExecutionCount++;
+        CapturedErrors.Add(error.Message);
+    }
+
+    protected Task TaskErrorActionAsync(IError error)
+    {
+        ErrorActionExecutionCount++;
+        CapturedErrors.Add(error.Message);
+        return Task.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskErrorActionAsync(IError error)
+    {
+        ErrorActionExecutionCount++;
+        CapturedErrors.Add(error.Message);
+        return ValueTask.CompletedTask;
+    }
+
+    protected void AssertActionInvocation(Result source, Result output)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(source.IsFailed ? 1 : 0);
+        ErrorActionExecutionCount.Should().Be(0);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertActionInvocation(Result<TValue> source, Result<TValue> output)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(source.IsFailed ? 1 : 0);
+        ErrorActionExecutionCount.Should().Be(0);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertErrorInvocation(Result source, Result output)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(0);
+        ErrorActionExecutionCount.Should().Be(source.IsFailed ? 2 : 0);
+        CapturedErrors.Should().Equal(source.IsFailed ? [ErrorMessage, SecondErrorMessage] : []);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertErrorInvocation(Result<TValue> source, Result<TValue> output)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(0);
+        ErrorActionExecutionCount.Should().Be(source.IsFailed ? 2 : 0);
+        CapturedErrors.Should().Equal(source.IsFailed ? [ErrorMessage, SecondErrorMessage] : []);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Task.Left.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTestsTaskLeft : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskLeftExecutesActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var result = Task.FromResult(isSuccess ? SucceededResult() : FailedResult());
+        var output = await result.TapErrorAsync(Action);
+
+        AssertActionInvocation(await result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskLeftExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = Task.FromResult(isSuccess ? SucceededResult() : FailedResult());
+        var output = await result.TapErrorAsync(ErrorAction);
+
+        AssertErrorInvocation(await result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskLeftTExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = Task.FromResult(isSuccess ? SucceededResultT() : FailedResultT());
+        var output = await result.TapErrorAsync(ErrorAction);
+
+        AssertErrorInvocation(await result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Task.Right.cs
@@ -1,0 +1,53 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTestsTaskRight : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskRightExecutesActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = await result.TapErrorAsync(TaskActionAsync);
+
+        AssertActionInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskRightExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = await result.TapErrorAsync(TaskErrorActionAsync);
+
+        AssertErrorInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskRightTExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = await result.TapErrorAsync(TaskErrorActionAsync);
+
+        AssertErrorInvocation(result, output);
+    }
+
+    [Test]
+    public async Task TapErrorTaskRightThrowsWhenFuncIsNull()
+    {
+        var action = () => Result.Fail(ErrorMessage).TapErrorAsync((Func<Task>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task TapErrorTaskRightThrowsWhenErrorFuncIsNull()
+    {
+        var action = () => Result.Fail(ErrorMessage).TapErrorAsync((Func<IError, Task>)null!);
+
+        await action.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.Task.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTestsTask : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskExecutesTaskActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorAsync(TaskActionAsync);
+
+        AssertActionInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskExecutesValueTaskActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorAsync(ValueTaskActionAsync);
+
+        AssertActionInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskExecutesErrorTaskActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorAsync(TaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskExecutesErrorValueTaskActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorAsync(ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorTaskTExecutesErrorTaskActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = await Task.FromResult(source).TapErrorAsync(TaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.ValueTask.Left.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTestsValueTaskLeft : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskLeftExecutesActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(Action);
+
+        AssertActionInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskLeftExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(ErrorAction);
+
+        AssertErrorInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskLeftTExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(ErrorAction);
+
+        AssertErrorInvocation(source, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.ValueTask.Right.cs
@@ -1,0 +1,37 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTestsValueTaskRight : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskRightExecutesActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = await result.TapErrorAsync(ValueTaskActionAsync);
+
+        AssertActionInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskRightExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = await result.TapErrorAsync(ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskRightTExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = await result.TapErrorAsync(ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(result, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.ValueTask.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTestsValueTask : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskExecutesValueTaskActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(ValueTaskActionAsync);
+
+        AssertActionInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskExecutesTaskActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(TaskActionAsync);
+
+        AssertActionInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskExecutesErrorValueTaskActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskExecutesErrorTaskActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(TaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task TapErrorValueTaskTExecutesErrorValueTaskActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var source = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = await ValueTask.FromResult(source).TapErrorAsync(ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorTests.cs
@@ -1,0 +1,64 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorTests : TapErrorTestsBase
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public void TapErrorExecutesActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = result.TapError(Action);
+
+        AssertActionInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public void TapErrorTExecutesActionOnFailureAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = result.TapError(Action);
+
+        AssertActionInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public void TapErrorExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = result.TapError(ErrorAction);
+
+        AssertErrorInvocation(result, output);
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public void TapErrorTExecutesErrorActionForEachErrorAndReturnsSelf(bool isSuccess)
+    {
+        var result = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = result.TapError(ErrorAction);
+
+        AssertErrorInvocation(result, output);
+    }
+
+    [Test]
+    public void TapErrorThrowsWhenActionIsNull()
+    {
+        var action = () => Result.Fail(ErrorMessage).TapError((Action)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void TapErrorThrowsWhenErrorActionIsNull()
+    {
+        var action = () => Result.Fail(ErrorMessage).TapError((Action<IError>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- add TapError for Result and Result<T>
- add async overloads for Task and ValueTask in left/right/task split files
- add unit tests for success/failure behavior, per-error execution, and null-guard edge cases
- document TapError usage in README

## Why
- issue #65 requests CSharpFunctionalExtensions-style TapError support in this library

## How to test
- run dotnet test --project tests/NKZSoft.FluentResults.Extensions.Functional.Tests/NKZSoft.FluentResults.Extensions.Functional.Tests.csproj

## Risks
- no behavioral changes to existing APIs; adds new overload surface only

Closes #65