### PR TITLE
feat(result): add TapErrorIf extensions and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,27 @@ var asyncOutput = await GetResultAsync()
 </details>
 
 <details>
+<summary><strong>TapErrorIf</strong></summary>
+
+Conditionally executes `TapError` logic.
+If the condition is false, it returns the original result unchanged.
+
+```csharp
+var output = Result.Fail("Validation failed")
+    .TapErrorIf(true, () => Log("failed"));
+
+var output2 = Result.Fail("Validation failed")
+    .TapErrorIf(true, error => Log(error.Message));
+
+public Task OnErrorAsync(IError error)
+...
+var output3 = await GetResultAsync()
+    .TapErrorIfAsync(true, OnErrorAsync);
+```
+
+</details>
+
+<details>
 <summary><strong>TapIf</strong></summary>
 
 Conditionally executes `Tap` logic.

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.Task.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.Task.Left.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapErrorIfAsync(this Task<Result> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapErrorIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapErrorIfAsync(this Task<Result> resultTask, bool condition, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapErrorIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.Task.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.Task.Right.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result> TapErrorIfAsync(this Result result, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result<TValue>> TapErrorIfAsync<TValue>(this Result<TValue> result, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function for each error when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result> TapErrorIfAsync(this Result result, bool condition, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : Task.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a task function for each error when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static Task<Result<TValue>> TapErrorIfAsync<TValue>(this Result<TValue> result, bool condition, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : Task.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.Task.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.Task.cs
@@ -1,0 +1,128 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapErrorIfAsync(this Task<Result> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapErrorIfAsync(this Task<Result> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapErrorIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapErrorIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapErrorIfAsync(this Task<Result> resultTask, bool condition, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result> TapErrorIfAsync(this Task<Result> resultTask, bool condition, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapErrorIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async Task<Result<TValue>> TapErrorIfAsync<TValue>(this Task<Result<TValue>> resultTask, bool condition, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.ValueTask.Left.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.ValueTask.Left.cs
@@ -1,0 +1,66 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapErrorIfAsync(this ValueTask<Result> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapErrorIfAsync(this ValueTask<Result> resultTask, bool condition, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return result.TapErrorIf(condition, action);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.ValueTask.Right.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.ValueTask.Right.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static ValueTask<Result> TapErrorIfAsync(this Result result, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this Result<TValue> result, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function for each error when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static ValueTask<Result> TapErrorIfAsync(this Result result, bool condition, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : ValueTask.FromResult(result);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function for each error when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this Result<TValue> result, bool condition, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        return condition ? result.TapErrorAsync(func) : ValueTask.FromResult(result);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.ValueTask.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.ValueTask.cs
@@ -1,0 +1,128 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapErrorIfAsync(this ValueTask<Result> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapErrorIfAsync(this ValueTask<Result> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapErrorIfAsync(this ValueTask<Result> resultTask, bool condition, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result> TapErrorIfAsync(this ValueTask<Result> resultTask, bool condition, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a valuetask function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The valuetask function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<IError, ValueTask> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a task function for each error when the supplied condition is true and the awaited result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="resultTask">The task producing the result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="func">The task function to execute for each error.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public static async ValueTask<Result<TValue>> TapErrorIfAsync<TValue>(this ValueTask<Result<TValue>> resultTask, bool condition, Func<IError, Task> func)
+    {
+        ArgumentNullException.ThrowIfNull(func);
+
+        var result = await resultTask.ConfigureAwait(false);
+        return await result.TapErrorIfAsync(condition, func).ConfigureAwait(false);
+    }
+}

--- a/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.cs
+++ b/src/NKZSoft.FluentResults.Extensions.Functional/Methods/TapErrorIf.cs
@@ -1,0 +1,62 @@
+namespace NKZSoft.FluentResults.Extensions.Functional;
+
+public static partial class ResultExtensions
+{
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result TapErrorIf(this Result result, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.TapError(action) : result;
+    }
+
+    /// <summary>
+    /// Executes an action when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapErrorIf<TValue>(this Result<TValue> result, bool condition, Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.TapError(action) : result;
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>The original result.</returns>
+    public static Result TapErrorIf(this Result result, bool condition, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.TapError(action) : result;
+    }
+
+    /// <summary>
+    /// Executes an action for each error when the supplied condition is true and the result is failed.
+    /// </summary>
+    /// <typeparam name="TValue">The result value type.</typeparam>
+    /// <param name="result">The source result.</param>
+    /// <param name="condition">Condition that controls whether the action runs.</param>
+    /// <param name="action">The action to execute for each error.</param>
+    /// <returns>The original result.</returns>
+    public static Result<TValue> TapErrorIf<TValue>(this Result<TValue> result, bool condition, Action<IError> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        return condition ? result.TapError(action) : result;
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Base.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Base.cs
@@ -1,0 +1,98 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+using Common;
+
+public abstract class TapErrorIfTestsBase : TestBase
+{
+    protected const string SecondErrorMessage = "Second Error Message";
+    protected const string SuccessMessage = "Success Message";
+
+    protected int ActionExecutionCount { get; private set; }
+    protected int ErrorActionExecutionCount { get; private set; }
+    protected List<string> CapturedErrors { get; } = [];
+
+    protected static Result FailedResult()
+        => Result.Fail(new Error(ErrorMessage))
+            .WithError(new Error(SecondErrorMessage))
+            .WithSuccess(SuccessMessage);
+
+    protected static Result<TValue> FailedResultT()
+        => Result.Fail<TValue>(new Error(ErrorMessage))
+            .WithError(new Error(SecondErrorMessage))
+            .WithSuccess(SuccessMessage);
+
+    protected static Result SucceededResult()
+        => Result.Ok().WithSuccess(SuccessMessage);
+
+    protected static Result<TValue> SucceededResultT()
+        => Result.Ok(TValue.Value).WithSuccess(SuccessMessage);
+
+    protected void Action()
+        => ActionExecutionCount++;
+
+    protected Task TaskActionAsync()
+    {
+        ActionExecutionCount++;
+        return Task.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskActionAsync()
+    {
+        ActionExecutionCount++;
+        return ValueTask.CompletedTask;
+    }
+
+    protected void ErrorAction(IError error)
+    {
+        ErrorActionExecutionCount++;
+        CapturedErrors.Add(error.Message);
+    }
+
+    protected Task TaskErrorActionAsync(IError error)
+    {
+        ErrorActionExecutionCount++;
+        CapturedErrors.Add(error.Message);
+        return Task.CompletedTask;
+    }
+
+    protected ValueTask ValueTaskErrorActionAsync(IError error)
+    {
+        ErrorActionExecutionCount++;
+        CapturedErrors.Add(error.Message);
+        return ValueTask.CompletedTask;
+    }
+
+    protected void AssertActionInvocation(Result source, Result output, bool condition)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(source.IsFailed && condition ? 1 : 0);
+        ErrorActionExecutionCount.Should().Be(0);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertActionInvocation(Result<TValue> source, Result<TValue> output, bool condition)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(source.IsFailed && condition ? 1 : 0);
+        ErrorActionExecutionCount.Should().Be(0);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertErrorInvocation(Result source, Result output, bool condition)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(0);
+        ErrorActionExecutionCount.Should().Be(source.IsFailed && condition ? 2 : 0);
+        CapturedErrors.Should().Equal(source.IsFailed && condition ? [ErrorMessage, SecondErrorMessage] : []);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+
+    protected void AssertErrorInvocation(Result<TValue> source, Result<TValue> output, bool condition)
+    {
+        output.Should().BeSameAs(source);
+        ActionExecutionCount.Should().Be(0);
+        ErrorActionExecutionCount.Should().Be(source.IsFailed && condition ? 2 : 0);
+        CapturedErrors.Should().Equal(source.IsFailed && condition ? [ErrorMessage, SecondErrorMessage] : []);
+        output.Successes.Should().ContainSingle(success => success.Message == SuccessMessage);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Task.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Task.Left.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTestsTaskLeft : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfTaskLeftExecutesActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorIfAsync(condition, Action);
+
+        AssertActionInvocation(source, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfTaskLeftExecutesErrorActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorIfAsync(condition, ErrorAction);
+
+        AssertErrorInvocation(source, output, condition);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Task.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Task.Right.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTestsTaskRight : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfTaskRightExecutesTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await source.TapErrorIfAsync(condition, TaskActionAsync);
+
+        AssertActionInvocation(source, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfTaskRightExecutesErrorTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await source.TapErrorIfAsync(condition, TaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output, condition);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Task.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.Task.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTestsTask : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfTaskExecutesValueTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorIfAsync(condition, ValueTaskActionAsync);
+
+        AssertActionInvocation(source, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfTaskExecutesErrorValueTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await Task.FromResult(source).TapErrorIfAsync(condition, ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output, condition);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.ValueTask.Left.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.ValueTask.Left.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTestsValueTaskLeft : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfValueTaskLeftExecutesActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorIfAsync(condition, Action);
+
+        AssertActionInvocation(source, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfValueTaskLeftExecutesErrorActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorIfAsync(condition, ErrorAction);
+
+        AssertErrorInvocation(source, output, condition);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.ValueTask.Right.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.ValueTask.Right.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTestsValueTaskRight : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfValueTaskRightExecutesValueTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await source.TapErrorIfAsync(condition, ValueTaskActionAsync);
+
+        AssertActionInvocation(source, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfValueTaskRightExecutesErrorValueTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await source.TapErrorIfAsync(condition, ValueTaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output, condition);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.ValueTask.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.ValueTask.cs
@@ -1,0 +1,30 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTestsValueTask : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfValueTaskExecutesTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorIfAsync(condition, TaskActionAsync);
+
+        AssertActionInvocation(source, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task TapErrorIfValueTaskExecutesErrorTaskActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var source = isSuccess ? SucceededResult() : FailedResult();
+        var output = await ValueTask.FromResult(source).TapErrorIfAsync(condition, TaskErrorActionAsync);
+
+        AssertErrorInvocation(source, output, condition);
+    }
+}

--- a/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.cs
+++ b/tests/NKZSoft.FluentResults.Extensions.Functional.Tests/TapErrorIfTests.cs
@@ -1,0 +1,59 @@
+namespace NKZSoft.FluentResults.Extensions.Functional.Tests;
+
+public sealed class TapErrorIfTests : TapErrorIfTestsBase
+{
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public void TapErrorIfExecutesActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = result.TapErrorIf(condition, Action);
+
+        AssertActionInvocation(result, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public void TapErrorIfExecutesErrorActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var result = isSuccess ? SucceededResult() : FailedResult();
+        var output = result.TapErrorIf(condition, ErrorAction);
+
+        AssertErrorInvocation(result, output, condition);
+    }
+
+    [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public void TapErrorIfTExecutesErrorActionConditionallyAndReturnsSelf(bool isSuccess, bool condition)
+    {
+        var result = isSuccess ? SucceededResultT() : FailedResultT();
+        var output = result.TapErrorIf(condition, ErrorAction);
+
+        AssertErrorInvocation(result, output, condition);
+    }
+
+    [Test]
+    public void TapErrorIfThrowsWhenActionIsNull()
+    {
+        var action = () => Result.Fail(ErrorMessage).TapErrorIf(true, (Action)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void TapErrorIfThrowsWhenErrorActionIsNull()
+    {
+        var action = () => Result.Fail(ErrorMessage).TapErrorIf(true, (Action<IError>)null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## What
- add TapErrorIf for Result and Result<T> with conditional sync overloads
- add async overloads for Task and ValueTask in left/right/task split files
- add unit tests for success/failure + condition combinations and null-guard edge cases
- document TapErrorIf usage in README

## Why
- issue #66 requests CSharpFunctionalExtensions-style TapErrorIf support in this library

## How to test
- run dotnet test --project tests/NKZSoft.FluentResults.Extensions.Functional.Tests/NKZSoft.FluentResults.Extensions.Functional.Tests.csproj

## Risks
- no changes to existing API behavior; adds new overload surface only

Closes #66